### PR TITLE
Add readmes and new collateral id query

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,15 @@
 This repository houses a Provenance Blockchain Metadata bilateral exchange smart contract, and a client library that allows
 interaction with it from a Kotlin application.  This project is based on the [Bilateral Exchange Smart Contract](https://github.com/provenance-io/bilateral-exchange).
 
-More details incoming as time progresses...
+## [Metadata Bilateral Exchange Smart Contract](./smart-contract)
+
+The Metadata Bilateral Exchange smart contract is written in Rust, leveraging the [Cosmwasm SDK](https://crates.io/crates/cosmwasm-std)
+and [Provwasm SDK](https://crates.io/crates/provwasm-std) to produce a WASM file compatible with the [Provenance Blockchain](https://github.com/provenance-io/provenance).
+This contract is designed to allow the bilateral exchange of [Provenance Blockchain Metadata Module](https://docs.provenance.io/modules/metadata-module) 
+and [Provenance Blockchain Marker Module](https://docs.provenance.io/modules/marker-module) goods for [coin](https://docs.provenance.io/blockchain/basics/stablecoin.
+
+## [Kotlin Client](./kotlin-client)
+
+The Kotlin client is written in Kotlin, leveraging the [PbClient](https://github.com/provenance-io/pb-grpc-client-kotlin)
+to facilitate requests to a [Provenance Blockchain](https://github.com/provenance-io/provenance) instance of the
+[Metadata Bilateral Exchange Smart Contract](./smart-contract).

--- a/kotlin-client/README.md
+++ b/kotlin-client/README.md
@@ -9,9 +9,32 @@ Provenance Blockchain instance of the [Metadata Bilateral Exchange smart contrac
 [![Maven Central][maven-badge]][maven-url]
 [![Apache 2.0 License][license-badge]][license-url]
 
+[maven-badge]: https://maven-badges.herokuapp.com/maven-central/io.provenance.bilateral/bilateral-client/badge.svg
+[maven-url]: https://maven-badges.herokuapp.com/maven-central/io.provenance.bilateral/bilateral-client
+[release-badge]: https://img.shields.io/github/tag/provenance-io/metadata-bilateral-exchange.svg
+[release-latest]: https://github.com/provenance-io/metadata-bilateral-exchange/releases/latest
 [license-badge]: https://img.shields.io/github/license/provenance-io/metadata-bilateral-exchange.svg
 [license-url]: https://github.com/provenance-io/metadata-bilateral-exchange/blob/main/LICENSE
-[maven-badge]: https://maven-badges.herokuapp.com/maven-central/io.provenance.classification.asset/ac-client/badge.svg
-[maven-url]: https://maven-badges.herokuapp.com/maven-central/io.provenance.classification.asset/ac-client
-[release-badge]: https://img.shields.io/github/tag/provenance-io/asset-classification-libs.svg
-[release-latest]: https://github.com/provenance-io/asset-classification-libs/releases/latest
+
+## Usage
+The `BilateralContractClient` includes functions that allow communication with an instance of the Metadata Bilateral
+Exchange smart contract.  It parallels all functionality, and it exposes data classes that translate to the request
+JSON required by the contract.
+
+Creating a new instance of the client:
+```kotlin
+import io.provenance.bilateral.client.BilateralContractClient
+import io.provenance.bilateral.util.ContractAddressResolver
+import io.provenance.client.grpc.GasEstimationMethod
+import io.provenance.client.grpc.PbClient
+import java.net.URI
+
+fun makeClient(): BilateralContractClient = BilateralContractClient.new(
+    pbClient = PbClient(
+        chainId = "chain-local",
+        channelUri = URI.create("http://localhost:9090"),
+        gasEstimationMethod = GasEstimationMethod.MSG_FEE_CALCULATION
+    ),
+    addressResolver = ContractAddressResolver.FromName("mycontractname.pb"),
+)
+```

--- a/kotlin-client/README.md
+++ b/kotlin-client/README.md
@@ -1,0 +1,17 @@
+# Metadata Bilateral Exchange Kotlin Client
+
+This is a [Kotlin](https://kotlinlang.org/)-based client that leverages [Provenance Blockchain's](https://provenance.io)
+[PbClient](https://github.com/provenance-io/pb-grpc-client-kotlin) to make [GRPC](https://grpc.io/) requests to a
+Provenance Blockchain instance of the [Metadata Bilateral Exchange smart contract](../smart-contract).
+
+## Status
+[![Latest Release][release-badge]][release-latest]
+[![Maven Central][maven-badge]][maven-url]
+[![Apache 2.0 License][license-badge]][license-url]
+
+[license-badge]: https://img.shields.io/github/license/provenance-io/metadata-bilateral-exchange.svg
+[license-url]: https://github.com/provenance-io/metadata-bilateral-exchange/blob/main/LICENSE
+[maven-badge]: https://maven-badges.herokuapp.com/maven-central/io.provenance.classification.asset/ac-client/badge.svg
+[maven-url]: https://maven-badges.herokuapp.com/maven-central/io.provenance.classification.asset/ac-client
+[release-badge]: https://img.shields.io/github/tag/provenance-io/asset-classification-libs.svg
+[release-latest]: https://github.com/provenance-io/asset-classification-libs/releases/latest

--- a/kotlin-client/src/integrationTest/kotlin/io/provenance/bilateral/contract/CoinTradeIntTest.kt
+++ b/kotlin-client/src/integrationTest/kotlin/io/provenance/bilateral/contract/CoinTradeIntTest.kt
@@ -1,7 +1,5 @@
 package io.provenance.bilateral.contract
 
-import io.provenance.bilateral.execute.CancelAsk
-import io.provenance.bilateral.execute.CancelBid
 import io.provenance.bilateral.execute.CreateAsk
 import io.provenance.bilateral.execute.CreateBid
 import io.provenance.bilateral.execute.ExecuteMatch
@@ -148,7 +146,7 @@ class CoinTradeIntTest : ContractIntTest() {
             message = "The base should be withdrawn from the asker's account",
         )
         bilateralClient.cancelAsk(
-            cancelAsk = CancelAsk.new(askUuid.toString()),
+            askId = askUuid.toString(),
             signer = BilateralAccounts.askerAccount,
         )
         bilateralClient.assertAskIsDeleted(askUuid.toString())
@@ -183,7 +181,7 @@ class CoinTradeIntTest : ContractIntTest() {
             message = "The quote should be withdrawn from the bidder's account",
         )
         bilateralClient.cancelBid(
-            cancelBid = CancelBid.new(bidUuid.toString()),
+            bidId = bidUuid.toString(),
             signer = BilateralAccounts.bidderAccount,
         )
         bilateralClient.assertBidIsDeleted(bidUuid.toString())

--- a/kotlin-client/src/integrationTest/kotlin/io/provenance/bilateral/contract/MarkerShareSaleIntTest.kt
+++ b/kotlin-client/src/integrationTest/kotlin/io/provenance/bilateral/contract/MarkerShareSaleIntTest.kt
@@ -1,7 +1,5 @@
 package io.provenance.bilateral.contract
 
-import io.provenance.bilateral.execute.CancelAsk
-import io.provenance.bilateral.execute.CancelBid
 import io.provenance.bilateral.execute.CreateAsk
 import io.provenance.bilateral.execute.CreateBid
 import io.provenance.bilateral.execute.ExecuteMatch
@@ -307,8 +305,7 @@ class MarkerShareSaleIntTest : ContractIntTest() {
                 signer = BilateralAccounts.askerAccount,
             )
         }
-        val cancelAsk = CancelAsk.new(askUuid.toString())
-        bilateralClient.cancelAsk(cancelAsk, BilateralAccounts.askerAccount)
+        bilateralClient.cancelAsk(askUuid.toString(), BilateralAccounts.askerAccount)
         bilateralClient.assertAskIsDeleted(askUuid.toString())
         val afterCancelGrant = pbClient.getMarkerAccount(markerDenom).accessControlList.assertSingle("Only a single permission should exist on the marker after cancelling the ask")
         assertEquals(
@@ -346,8 +343,7 @@ class MarkerShareSaleIntTest : ContractIntTest() {
             actual = pbClient.getBalance(BilateralAccounts.bidderAccount.address(), bidderDenom),
             message = "All bidder denom [$bidderDenom] should be held in contract escrow after creating the bid",
         )
-        val cancelBid = CancelBid.new(bidUuid.toString())
-        bilateralClient.cancelBid(cancelBid, BilateralAccounts.bidderAccount)
+        bilateralClient.cancelBid(bidUuid.toString(), BilateralAccounts.bidderAccount)
         bilateralClient.assertBidIsDeleted(bidUuid.toString())
         assertEquals(
             expected = 100L,

--- a/kotlin-client/src/integrationTest/kotlin/io/provenance/bilateral/contract/MarkerTradeIntTest.kt
+++ b/kotlin-client/src/integrationTest/kotlin/io/provenance/bilateral/contract/MarkerTradeIntTest.kt
@@ -1,7 +1,5 @@
 package io.provenance.bilateral.contract
 
-import io.provenance.bilateral.execute.CancelAsk
-import io.provenance.bilateral.execute.CancelBid
 import io.provenance.bilateral.execute.CreateAsk
 import io.provenance.bilateral.execute.CreateBid
 import io.provenance.bilateral.execute.ExecuteMatch
@@ -159,8 +157,7 @@ class MarkerTradeIntTest : ContractIntTest() {
                 .none { accessGrant -> accessGrant.address == BilateralAccounts.askerAccount.address() },
             message = "The contract should remove access for the asker from the marker after receiving it",
         )
-        val cancelAsk = CancelAsk.new(askUuid.toString())
-        bilateralClient.cancelAsk(cancelAsk, BilateralAccounts.askerAccount)
+        bilateralClient.cancelAsk(askUuid.toString(), BilateralAccounts.askerAccount)
         bilateralClient.assertAskIsDeleted(askUuid.toString())
         val grant = pbClient.getMarkerAccount(markerDenom).accessControlList.assertSingle("Only a single access control should exist on the marker after cancelling the ask")
         assertEquals(
@@ -196,8 +193,7 @@ class MarkerTradeIntTest : ContractIntTest() {
             actual = pbClient.getBalance(BilateralAccounts.bidderAccount.address(), bidderDenom),
             message = "Expected all the required bidder denom [$bidderDenom] to be held in contract escrow",
         )
-        val cancelBid = CancelBid.new(bidUuid.toString())
-        bilateralClient.cancelBid(cancelBid, BilateralAccounts.bidderAccount)
+        bilateralClient.cancelBid(bidUuid.toString(), BilateralAccounts.bidderAccount)
         bilateralClient.assertBidIsDeleted(bidUuid.toString())
         assertEquals(
             expected = 100L,

--- a/kotlin-client/src/integrationTest/kotlin/io/provenance/bilateral/contract/QueryIntTest.kt
+++ b/kotlin-client/src/integrationTest/kotlin/io/provenance/bilateral/contract/QueryIntTest.kt
@@ -1,0 +1,41 @@
+package io.provenance.bilateral.contract
+
+import io.provenance.bilateral.execute.CreateAsk
+import org.junit.jupiter.api.Test
+import testconfiguration.accounts.BilateralAccounts
+import testconfiguration.functions.assertAskExists
+import testconfiguration.functions.assertAskIsDeleted
+import testconfiguration.functions.assertNotNull
+import testconfiguration.functions.assertNull
+import testconfiguration.functions.assertSucceeds
+import testconfiguration.functions.newCoins
+import testconfiguration.testcontainers.ContractIntTest
+import java.util.UUID
+import kotlin.test.assertFails
+
+class QueryIntTest : ContractIntTest() {
+    @Test
+    fun testGetAskByCollateralId() {
+        assertFails("A missing id should cause an exception") { bilateralClient.getAskByCollateralId("some id whatever") }
+        bilateralClient.getAskByCollateralIdOrNull("fakeid").assertNull("The OrNull variant should return null for a missing id")
+        val coinTradeAskUuid = UUID.randomUUID()
+        testAndCleanupAsk(
+            ask = CreateAsk.newCoinTrade(
+                id = coinTradeAskUuid.toString(),
+                quote = newCoins(100, "nhash"),
+                base = newCoins(150, "nhash"),
+                descriptor = null,
+            ),
+            expectedId = coinTradeAskUuid.toString(),
+        )
+    }
+
+    private fun testAndCleanupAsk(ask: CreateAsk, expectedId: String) {
+        bilateralClient.createAsk(ask, BilateralAccounts.askerAccount)
+        bilateralClient.assertAskExists(ask.getId())
+        assertSucceeds("Expected the ask to be available by collateral id") { bilateralClient.getAskByCollateralId(expectedId) }
+        bilateralClient.getAskByCollateralIdOrNull(expectedId).assertNotNull("ask should not be null when fetching by collateral id")
+        bilateralClient.cancelAsk(ask.getId(), BilateralAccounts.askerAccount)
+        bilateralClient.assertAskIsDeleted(ask.getId())
+    }
+}

--- a/kotlin-client/src/integrationTest/kotlin/io/provenance/bilateral/contract/RequiredAttributesIntTest.kt
+++ b/kotlin-client/src/integrationTest/kotlin/io/provenance/bilateral/contract/RequiredAttributesIntTest.kt
@@ -4,8 +4,6 @@ import cosmos.base.v1beta1.CoinOuterClass.Coin
 import cosmos.tx.v1beta1.ServiceOuterClass
 import io.provenance.attribute.v1.AttributeType
 import io.provenance.attribute.v1.MsgAddAttributeRequest
-import io.provenance.bilateral.execute.CancelAsk
-import io.provenance.bilateral.execute.CancelBid
 import io.provenance.bilateral.execute.CreateAsk
 import io.provenance.bilateral.execute.CreateBid
 import io.provenance.bilateral.execute.ExecuteMatch
@@ -196,9 +194,9 @@ class RequiredAttributesIntTest : ContractIntTest() {
         }
         bilateralClient.assertAskExists(secondAskUuid.toString(), "Expected the ask to exist because a match was never made")
         bilateralClient.assertBidExists(secondBidUuid.toString(), "Expected the bid to exist because a match was never made")
-        bilateralClient.cancelAsk(CancelAsk.new(secondAskUuid.toString()), BilateralAccounts.askerAccount)
+        bilateralClient.cancelAsk(secondAskUuid.toString(), BilateralAccounts.askerAccount)
         bilateralClient.assertAskIsDeleted(secondAskUuid.toString())
-        bilateralClient.cancelBid(CancelBid.new(secondBidUuid.toString()), BilateralAccounts.bidderAccount)
+        bilateralClient.cancelBid(secondBidUuid.toString(), BilateralAccounts.bidderAccount)
         bilateralClient.assertBidIsDeleted(secondBidUuid.toString())
     }
 

--- a/kotlin-client/src/integrationTest/kotlin/io/provenance/bilateral/contract/ScopeTradeIntTest.kt
+++ b/kotlin-client/src/integrationTest/kotlin/io/provenance/bilateral/contract/ScopeTradeIntTest.kt
@@ -1,7 +1,5 @@
 package io.provenance.bilateral.contract
 
-import io.provenance.bilateral.execute.CancelAsk
-import io.provenance.bilateral.execute.CancelBid
 import io.provenance.bilateral.execute.CreateAsk
 import io.provenance.bilateral.execute.CreateBid
 import io.provenance.bilateral.execute.ExecuteMatch
@@ -113,8 +111,7 @@ class ScopeTradeIntTest : ContractIntTest() {
         )
         bilateralClient.createAsk(createAsk, BilateralAccounts.askerAccount)
         bilateralClient.assertAskExists(askUuid.toString())
-        val cancelAsk = CancelAsk.new(askUuid.toString())
-        bilateralClient.cancelAsk(cancelAsk, BilateralAccounts.askerAccount)
+        bilateralClient.cancelAsk(askUuid.toString(), BilateralAccounts.askerAccount)
         val scopeInfo = pbClient.metadataClient.scope(ScopeRequest.newBuilder().setScopeId(scopeUuid.toString()).build())
         assertEquals(
             expected = BilateralAccounts.askerAccount.address(),
@@ -151,8 +148,7 @@ class ScopeTradeIntTest : ContractIntTest() {
             actual = pbClient.getBalance(BilateralAccounts.bidderAccount.address(), bidderDenom),
             message = "Expected the bidder's [$bidderDenom] coin to be held in escrow when the bid is created",
         )
-        val cancelBid = CancelBid.new(bidUuid.toString())
-        bilateralClient.cancelBid(cancelBid, BilateralAccounts.bidderAccount)
+        bilateralClient.cancelBid(bidUuid.toString(), BilateralAccounts.bidderAccount)
         bilateralClient.assertBidIsDeleted(bidUuid.toString())
         assertEquals(
             expected = 10000L,

--- a/kotlin-client/src/integrationTest/kotlin/testconfiguration/functions/TestAssertions.kt
+++ b/kotlin-client/src/integrationTest/kotlin/testconfiguration/functions/TestAssertions.kt
@@ -48,6 +48,13 @@ fun <T> T?.assertNotNull(message: String = "Expected value to not be null"): T {
     return this
 }
 
+fun <T> T?.assertNull(message: String = "Expected value to be null") {
+    kotlin.test.assertNull(
+        actual = this,
+        message = message,
+    )
+}
+
 fun <T> Collection<T>.assertSingle(message: String = "Expected a single value to exist within the collection"): T {
     val value = this.singleOrNull()
     kotlin.test.assertNotNull(

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/client/BilateralContractClient.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/client/BilateralContractClient.kt
@@ -19,6 +19,7 @@ import io.provenance.bilateral.models.BidOrder
 import io.provenance.bilateral.models.ContractInfo
 import io.provenance.bilateral.query.ContractSearchResult
 import io.provenance.bilateral.query.GetAsk
+import io.provenance.bilateral.query.GetAskByCollateralId
 import io.provenance.bilateral.query.GetBid
 import io.provenance.bilateral.query.GetContractInfo
 import io.provenance.bilateral.query.SearchAsks
@@ -55,6 +56,10 @@ class BilateralContractClient private constructor(
 
     fun getAskOrNull(id: String): AskOrder? = tryOrNull { getAsk(id) }
 
+    fun getAskByCollateralId(collateralId: String): AskOrder = queryContract(GetAskByCollateralId.new(collateralId))
+
+    fun getAskByCollateralIdOrNull(collateralId: String): AskOrder? = tryOrNull { getAskByCollateralId(collateralId) }
+
     fun getBid(id: String): BidOrder = queryContract(GetBid.new(id))
 
     fun getBidOrNull(id: String): BidOrder? = tryOrNull { getBid(id) }
@@ -90,16 +95,16 @@ class BilateralContractClient private constructor(
     ): BroadcastTxResponse = executeContract(createBid, signer, options, funds = createBid.getFunds())
 
     fun cancelAsk(
-        cancelAsk: CancelAsk,
+        askId: String,
         signer: Signer,
         options: BroadcastOptions = BroadcastOptions()
-    ): BroadcastTxResponse = executeContract(cancelAsk, signer, options, funds = emptyList())
+    ): BroadcastTxResponse = executeContract(CancelAsk.new(askId), signer, options, funds = emptyList())
 
     fun cancelBid(
-        cancelBid: CancelBid,
+        bidId: String,
         signer: Signer,
         options: BroadcastOptions = BroadcastOptions()
-    ): BroadcastTxResponse = executeContract(cancelBid, signer, options, funds = emptyList())
+    ): BroadcastTxResponse = executeContract(CancelBid.new(bidId), signer, options, funds = emptyList())
 
     // IMPORTANT: The Signer used in this function must be the contract's admin account.  This value can be found by
     // running getContractInfo()

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/execute/CreateAsk.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/execute/CreateAsk.kt
@@ -250,7 +250,15 @@ data class CreateAsk(
     }
 
     @JsonIgnore
-    internal fun getFunds(): List<Coin> = mapAsk(
+    fun getId(): String = mapAsk(
+        coinTrade = { coinTrade -> coinTrade.id },
+        markerTrade = { markerTrade -> markerTrade.id },
+        markerShareSale = { markerShareSale -> markerShareSale.id },
+        scopeTrade = { scopeTrade -> scopeTrade.id },
+    )
+
+    @JsonIgnore
+    fun getFunds(): List<Coin> = mapAsk(
         coinTrade = { coinTrade -> coinTrade.base },
         markerTrade = { emptyList() },
         markerShareSale = { emptyList() },

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/execute/CreateBid.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/execute/CreateBid.kt
@@ -232,7 +232,15 @@ data class CreateBid(val createBid: Body) : ContractExecuteMsg {
     }
 
     @JsonIgnore
-    internal fun getFunds(): List<Coin> = mapBid(
+    fun getId(): String = mapBid(
+        coinTrade = { coinTrade -> coinTrade.id },
+        markerTrade = { markerTrade -> markerTrade.id },
+        markerShareSale = { markerShareSale -> markerShareSale.id },
+        scopeTrade = { scopeTrade -> scopeTrade.id },
+    )
+
+    @JsonIgnore
+    fun getFunds(): List<Coin> = mapBid(
         coinTrade = { coinTrade -> coinTrade.quote },
         markerTrade = { markerTrade -> markerTrade.quote },
         markerShareSale = { markerShareSale -> markerShareSale.quote },

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/query/GetAskByCollateralId.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/query/GetAskByCollateralId.kt
@@ -1,0 +1,29 @@
+package io.provenance.bilateral.query
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy
+import com.fasterxml.jackson.databind.annotation.JsonNaming
+import io.provenance.bilateral.interfaces.ContractQueryMsg
+
+/*
+    {
+        "get_ask_by_collateral_id": {
+            "collateral_id": "tp1gy7q48cyj597tcarglvxjl3ce7l64t5egxpetq"
+        }
+    }
+ */
+/**
+ * This request searches for an ask by its collateral id.  Each ask type's collateral id differs:
+ * - Coin Trade: Identical to the ask id.
+ * - Marker Trade: The marker's bech32 address (NOT denom).
+ * - Marker Share Sale: The marker's bech32 address (NOT denom).
+ * - Scope Trade: The scope's bech32 address.
+ */
+@JsonNaming(SnakeCaseStrategy::class)
+data class GetAskByCollateralId(val getAskByCollateralId: Body) : ContractQueryMsg {
+    @JsonNaming(SnakeCaseStrategy::class)
+    data class Body(val collateralId: String)
+
+    companion object {
+        fun new(collateralId: String): GetAskByCollateralId = GetAskByCollateralId(Body(collateralId))
+    }
+}

--- a/smart-contract/README.md
+++ b/smart-contract/README.md
@@ -4,6 +4,15 @@ This a [CosmWasm](https://crates.io/crates/cosmwasm-std) smart contract that pro
 [Provenance Blockchain](https://docs.provenance.io) [markers](https://docs.provenance.io/modules/marker-module),
 [coin](https://docs.provenance.io/blockchain/basics/stablecoin) and [scopes](https://docs.provenance.io/modules/metadata-module#scope-data-structures).
 
+## Status
+[![Latest Release][release-badge]][release-latest]
+[![Apache 2.0 License][license-badge]][license-url]
+
+[release-badge]: https://img.shields.io/github/tag/provenance-io/metadata-bilateral-exchange.svg
+[release-latest]: https://github.com/provenance-io/metadata-bilateral-exchange/releases/latest
+[license-badge]: https://img.shields.io/github/license/provenance-io/metadata-bilateral-exchange.svg
+[license-url]: https://github.com/provenance-io/metadata-bilateral-exchange/blob/main/LICENSE
+
 ## Functions and Terminology
 
 The contract functions by allowing two parties to exchange owned goods on the blockchain with a three step process:

--- a/smart-contract/README.md
+++ b/smart-contract/README.md
@@ -1,11 +1,170 @@
-## Bilateral Exchange Smart Contract
+# Metadata Bilateral Exchange Smart Contract
 
-This a CosmWasm smart contract that provides the bilateral exchange of Provenance Blockchain `markers`, `coin` and `scopes`.
+This a [CosmWasm](https://crates.io/crates/cosmwasm-std) smart contract that provides the bilateral exchange of 
+[Provenance Blockchain](https://docs.provenance.io) [markers](https://docs.provenance.io/modules/marker-module),
+[coin](https://docs.provenance.io/blockchain/basics/stablecoin) and [scopes](https://docs.provenance.io/modules/metadata-module#scope-data-structures).
 
-## Build
+## Functions and Terminology
+
+The contract functions by allowing two parties to exchange owned goods on the blockchain with a three step process:
+ask, bid, and match.
+
+### Ask
+An ask is when an account invokes the `create_ask` execution route of the contract, stating that they will offer their
+goods (marker, scope, or coin - a.k.a. "the base") for another account's coin (a.k.a. "the quote").  When an ask is placed,
+the base is held by the contract until a match or a cancellation occurs.
+
+### Bid
+A bid is when an account invokes the `create_bid` execution route of the contract, stating that they will offer coin (a.k.a. "the quote")
+for an asker's goods (marker, scope, or coin - a.k.a. "the base").  When the bid is placed, the quote funds are held by
+the contract until a match or a cancellation occurs.
+
+### Match
+A match is when an ask and a bid are considered to be valid for each other, and the exchange of goods commences.  A match
+can only occur when the bidder has placed the appropriate quote that matches the asker's specifications.  Once the match
+is completed, the asker will receive the requested quote funds in coin, and the bidder will receive the goods specified
+by the asker.  Matches must be executed by the contract's admin account.
+
+### Cancellation
+At any time before a match occurs, an asker or bidder may cancel their ask or bid order.  When this occurs, any goods
+held by the contract on the behalf of the asker or bidder will be returned to the originating account in totality.
+
+### Collateral
+During each placement of ask or bid, a coin, scope, or marker will be held by the contract using various means of 
+ensuring that the contract is the sole owner of the object until a match or cancellation occurs.  The held values are 
+stored in the contract's internal storage in the form of an `AskOrder` or `BidOrder`.  These values can be searched for
+and queried at any time to ensure full transparency of the held goods by the contract.
+
+### Trade Types
+The contract allows for four types of trade.  In all trade types, the bidder sends coin as the quote in exchange for
+an asker's goods.
+
+#### Coin Trade
+In this trade, the asker sends coin as the base.  When a match is made, the asker simply receives their
+quote coin and the bidder receives their base coin, completing the trade.
+
+#### Marker Trade
+In this trade, the asker sends a marker as the base.  The contract's address must be given admin 
+permissions on the marker prior to the asker invoking the `create_ask` execution route for this trade type to be accepted.
+Additionally, only an administrator of a marker may list a marker for trade. At least one of the marker's coins must 
+remain in the marker's account holdings, and the asker specifies how much should be paid per coin by the bidder.  The 
+marker is then stripped of all permissions by the contract to ensure that no modifications can be made before a 
+cancellation or match occurs.  On a match, the asker then receives their quote, and the bidder receives permissions on 
+the marker equal to those that the asker possessed when they listed it.  On a cancellation, the asker just receives
+their permissions again on the marker.  Note: The contract will automatically remove its own permissions on the marker
+as soon as the match is completed or the ask is cancelled.
+
+#### Marker Share Sale
+In this trade, the asker lists an amount of marker-held denom as the base.  The contract's address must be given admin
+AND withdraw permissions on the marker prior to the asker invoking the `create_ask` execution route for this trade type
+to be accepted.  Additionally, only an administrator of the marker may list a marker for trade and at least one of the
+marker's coins must remain in the marker's account holdings.  The marker is then stripped of all permissions by the
+contract to ensure that no modifications can be made before a cancellation or match occurs.  The behavior of this listing
+differs based on the share sale type:
+
+* _Single Share Sale_: In this type, the asker chooses a `share_count`, which specifies how many shares of the marker
+will be sold.  This number must, of course, be less than or equal to the remaining marker shares held by the marker
+account.  The asker also specifies a `quote_per_share`, which indicates how much each share will be sold for. After a match occurs,
+the asker is sent the quote funds from the bidder, and the asker's marker permissions are restored.  The bidder receives
+as many shares as were listed as the `share_count` value, and the ask and bid orders are deleted from the contract.
+
+_Example_: If the asker lists `10` as the `share_count` and `20nhash` as the `quote_per_share`, then the bidder must list a quote of
+`10` purchased shares at `200nhash`.  This will produce a valid match and the trade can occur.
+
+* _Multiple Share Sale_: In this type, the asker specifies a `remove_sale_share_threshold`, which indicates the amount
+of shares remaining at the end of the sale.  If no value is provided, the contract assumes the value to be zero and will
+not stop the sale until all marker shares have been sold to bidders.  Like the single share type, the asker also provides
+a `quote_per_share` value, specifying how much each share costs to purchase.  Each bidder provides how many shares they
+wish to purchase, as well as a properly calculated quote.  When a match is made, the asker receives the quote from the
+bidder, and the bidder receives their specified count of shares.  The contract then determines if the marker has any
+shares remaining above the `remove_sale_share_threshold`.  If it does, the ask remains available and more bids can be
+matched against it.  If it does not, the ask is deleted and the marker permissions are restored to the asker.  In all
+cases, the bid order is always deleted after the bidder receives their marker shares.  A match will never be accepted if
+the bid intends to purchase enough shares to reduce the marker's share holdings beneath the `remove_sale_share_threshold`.
+
+_Example_: The asker has a marker with 100 shares of `markerdenom`.  They list the `remove_sale_share_threshold` as `50` and the 
+`quote_per_share` as `10nhash`.  A bidder produces a request for `15` shares with the proper quote of `150nhash`.  The
+match is made, the asker receives `150nhash` the bidder receives `15markerdenom` and the bid is deleted.  The remaining
+balance of shares is 85, so the ask remains in the contract and the marker is not yet returned to the asker.  A second
+bid comes in for `35` shares at `350nhash`.  The match is made, the asker receives `350nhash` and the bidder receives
+`35markerdenom`.  The ask and bid are deleted, and the asker receives their permissions to the marker again.
+
+#### Scope Trade
+In this trade, the asker lists a scope as the base, and a coin request as the quote.  The contract must be listed as the sole `owner` in the scope's
+ownership array, and the contract must also be listed as the `value_owner_address`.  Due to this requirement, it is
+highly recommended that the transfer of ownership from the asker to the contract on the scope be bundled into the same
+transaction that creates the ask to ensure that the scope is not "trapped" as owned by the contract if the create ask
+fails.  A scope would be "trapped" because the contract would own it, but not have any `AskOrder` record of it, preventing
+the contract from returning the scope with a `cancel_ask` execution route invocation.
+
+When a match is made, asker receives the quote coins, the bidder is assigned as the sole `owner` and `value_owner` of
+the scope, and both ask and bids are deleted.
+
+## Build and Deployment
+
+### Build Contract:
+To create a local `.wasm` file representation of the contract for deployment to the [Provenance Blockchain](https://provenance.io),
+just run the following:
+```bash
+make optimize
+```
+The contract will then be output to a local `artifacts` directory.
+
+### Store Contract:
+After the `.wasm` file is built, it needs to be stored on the chain.  To do so, some variation of the following command
+must be run with the `provenanced` tool provided by the [Provenance Repository](https://github.com/provenance-io/provenance):
 
 ```bash
-make
+provenanced tx wasm store ~/path/to/this-directory/artifacts/metadata_bilateral_exchange.wasm \
+--instantiate-only-address "some-admin-account-bech32" \
+--from same-admin-account-key \
+--home key/home \
+--chain-id chain-local \
+--gas auto \
+--gas-prices="1905nhash" \
+--gas-adjustment=1.2 \
+--broadcast-mode block \
+--testnet \
+--output json
 ```
 
-### Readme currently under construction
+On a success, keep a record of the `code_id` value produced by the transaction.  This will be used to instantiate
+the contract.
+
+_Keep in mind_:
+* An `instantiate-only-address` is not required.  If this flag is given, only the address supplied will ever be able
+to use the code instance created.
+* The `from` flag refers to the directory that your account keys are stored within.  This can be any directory, and will
+automatically be created when `provenanced keys add` command is used with a `home` flag.
+* The `chain-id` flag in this example refers to a localnet.  This is the target environment.  For instance, deployments
+to the standard provenance testnet environment will use `pio-testnet-1` here.
+
+### Instantiate Contract:
+With your stored contract's `code_id`, run the following command to instantiate this contract in the target environment:
+
+```bash
+provenanced tx wasm instantiate 169 \ 
+  '{
+   "bind_name": "mybindingname.pb",
+   "contract_name": "Metadata Bilateral Exchange"
+ }' \
+  --admin "some-admin-account-bech32" \
+  --from same-admin-account-key \
+  --label bilateral \
+  --chain-id chain-local \
+  --gas auto \
+  --gas-adjustment 1.1 \
+  --home build/node0 \
+  --broadcast-mode block \
+  --testnet \
+  --output json
+```
+
+On a success, a `contract_address` value will be produced, indicating that the contract has been successfully instantiated
+on the chain and can be interacted with using that address.  
+
+_Keep in mind_:
+* The `bind_name` value in the json will bind a [Provenance Blockchain Name](https://docs.provenance.io/modules/name-module)
+to the contract that can be used to resolve the contract's address.
+* If the `instantiate-only-address` was used in the previous step, that same address must be used in this step as the
+`admin` address.

--- a/smart-contract/src/contract.rs
+++ b/smart-contract/src/contract.rs
@@ -6,6 +6,7 @@ use crate::execute::execute_match::execute_match;
 use crate::instantiate::instantiate_contract::instantiate_contract;
 use crate::migrate::migrate_contract::migrate_contract;
 use crate::query::get_ask::query_ask;
+use crate::query::get_ask_by_collateral_id::query_ask_by_collateral_id;
 use crate::query::get_bid::query_bid;
 use crate::query::get_contract_info::query_contract_info;
 use crate::query::search_asks::search_asks;
@@ -54,6 +55,9 @@ pub fn query(
 ) -> Result<Binary, ContractError> {
     match msg {
         QueryMsg::GetAsk { id } => query_ask(deps, id),
+        QueryMsg::GetAskByCollateralId { collateral_id } => {
+            query_ask_by_collateral_id(deps, collateral_id)
+        }
         QueryMsg::GetBid { id } => query_bid(deps, id),
         QueryMsg::GetContractInfo {} => query_contract_info(deps),
         QueryMsg::SearchAsks { search } => search_asks(deps, search),

--- a/smart-contract/src/query/get_ask_by_collateral_id.rs
+++ b/smart-contract/src/query/get_ask_by_collateral_id.rs
@@ -1,0 +1,58 @@
+use crate::storage::ask_order_storage::get_ask_order_by_collateral_id;
+use crate::types::core::error::ContractError;
+use crate::util::extensions::ResultExtensions;
+use cosmwasm_std::{to_binary, Binary, Deps};
+use provwasm_std::ProvenanceQuery;
+
+pub fn query_ask_by_collateral_id(
+    deps: Deps<ProvenanceQuery>,
+    collateral_id: String,
+) -> Result<Binary, ContractError> {
+    to_binary(&get_ask_order_by_collateral_id(
+        deps.storage,
+        collateral_id,
+    )?)?
+    .to_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::query::get_ask_by_collateral_id::query_ask_by_collateral_id;
+    use crate::storage::ask_order_storage::{get_ask_order_by_collateral_id, insert_ask_order};
+    use crate::test::mock_marker::DEFAULT_MARKER_DENOM;
+    use crate::test::request_helpers::{mock_ask_marker_trade, mock_ask_order};
+    use crate::types::core::error::ContractError;
+    use crate::types::request::ask_types::ask_order::AskOrder;
+    use cosmwasm_std::from_binary;
+    use provwasm_mocks::mock_dependencies;
+
+    #[test]
+    fn test_get_ask_by_collateral_id() {
+        let mut deps = mock_dependencies(&[]);
+        let err = get_ask_order_by_collateral_id(deps.as_ref().storage, "some_fake_id")
+            .expect_err("an error should occur when no collateral id exists");
+        assert!(
+            matches!(err, ContractError::StorageError { .. }),
+            "a storage error should occur when the ask order cannot be found, but got: {:?}",
+            err,
+        );
+        // The storage function already has testing for all ask order types, so we just need to
+        // ensure the binary portion works here to have a fully-tested set of functionality
+        let ask_order = mock_ask_order(mock_ask_marker_trade(
+            "collateral_id",
+            DEFAULT_MARKER_DENOM,
+            100,
+            &[],
+        ));
+        insert_ask_order(deps.as_mut().storage, &ask_order)
+            .expect("the ask order should insert successfully");
+        let binary = query_ask_by_collateral_id(deps.as_ref(), "collateral_id".to_string())
+            .expect("expected binary to be properly produced from the query");
+        let deserialized_ask_order = from_binary::<AskOrder>(&binary)
+            .expect("expected the binary to deserialize to an ask order");
+        assert_eq!(
+            ask_order, deserialized_ask_order,
+            "expected the inserted value to be identical to the deserialized value",
+        );
+    }
+}

--- a/smart-contract/src/query/mod.rs
+++ b/smart-contract/src/query/mod.rs
@@ -1,4 +1,5 @@
 pub mod get_ask;
+pub mod get_ask_by_collateral_id;
 pub mod get_bid;
 pub mod get_contract_info;
 pub mod search_asks;

--- a/smart-contract/src/types/core/msg.rs
+++ b/smart-contract/src/types/core/msg.rs
@@ -39,6 +39,7 @@ pub enum ExecuteMsg {
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
     GetAsk { id: String },
+    GetAskByCollateralId { collateral_id: String },
     GetBid { id: String },
     GetContractInfo {},
     SearchAsks { search: Search },


### PR DESCRIPTION
# Features
- Adds readmes for both the contract and client, and freshens up the main readme.
- Adds a new query, `get_by_collateral_id` to the contract, and adds that functionality to the kotlin client
- Flattens the `deleteAsk` and `deleteBid` functions of the kotlin client to now just accept string ids instead of mandating the execute objects for simplicty.