### PR TITLE
Features: Match Reports, Asker Executed Matches, and Mismatch Quote Matches

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,7 +40,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --manifest-path=./smart-contract/Cargo.toml --verbose --features=enable-test-utils
+          args: --manifest-path=./smart-contract/Cargo.toml --verbose
 
   check-client:
     name: Check Kotlin Client Integrity
@@ -63,4 +63,3 @@ jobs:
 
       - name: Run Integration Tests
         run: ./kotlin-client/gradlew --info integrationTest --project-dir ./kotlin-client
-  

--- a/kotlin-client/src/integrationTest/kotlin/io/provenance/bilateral/contract/CoinTradeIntTest.kt
+++ b/kotlin-client/src/integrationTest/kotlin/io/provenance/bilateral/contract/CoinTradeIntTest.kt
@@ -22,6 +22,7 @@ import testconfiguration.testcontainers.ContractIntTest
 import java.time.OffsetDateTime
 import java.util.UUID
 import kotlin.test.assertEquals
+import kotlin.test.assertFails
 import kotlin.test.assertNull
 
 class CoinTradeIntTest : ContractIntTest() {
@@ -39,7 +40,6 @@ class CoinTradeIntTest : ContractIntTest() {
             initialHoldings = newCoin(1000, bidderDenom),
             receiverAddress = BilateralAccounts.bidderAccount.address(),
         )
-        // Simple trade of nhash for nhash
         val quote = newCoins(1000, bidderDenom)
         val base = newCoins(1000, askerDenom)
         val askUuid = UUID.randomUUID()
@@ -92,9 +92,113 @@ class CoinTradeIntTest : ContractIntTest() {
             askId = askUuid.toString(),
             bidId = bidUuid.toString(),
         )
-        assertSucceeds("Match shhould be executed without error") {
+        assertSucceeds("Match should be executed without error") {
             bilateralClient.executeMatch(
                 executeMatch = executeMatch,
+                signer = BilateralAccounts.adminAccount,
+            )
+        }
+        bilateralClient.assertAskIsDeleted(askUuid.toString())
+        bilateralClient.assertBidIsDeleted(bidUuid.toString())
+        val askerBalances = pbClient.getBalanceMap(BilateralAccounts.askerAccount.address())
+        assertNull(
+            actual = askerBalances[askerDenom],
+            message = "The asker should no longer have any [$askerDenom] because it should have been sent to the bidder",
+        )
+        assertEquals(
+            expected = 1000L,
+            actual = askerBalances[bidderDenom],
+            message = "The asker should have received all of the bidder's [$bidderDenom]",
+        )
+        val bidderBalances = pbClient.getBalanceMap(BilateralAccounts.bidderAccount.address())
+        assertNull(
+            actual = bidderBalances[bidderDenom],
+            message = "The bidder should no longer have any [$bidderDenom] because it should have been sent to the asker",
+        )
+        assertEquals(
+            expected = 1000L,
+            actual = bidderBalances[askerDenom],
+            message = "The bidder should have received all of the asker's [$askerDenom]"
+        )
+    }
+
+    @Test
+    fun testMismatchedBidExecute() {
+        val askerDenom = "cointrademismatchedask"
+        val bidderDenom = "cointrademismatchedbid"
+        giveTestDenom(
+            pbClient = pbClient,
+            initialHoldings = newCoin(1000, askerDenom),
+            receiverAddress = BilateralAccounts.askerAccount.address(),
+        )
+        giveTestDenom(
+            pbClient = pbClient,
+            initialHoldings = newCoin(1000, bidderDenom),
+            receiverAddress = BilateralAccounts.bidderAccount.address(),
+        )
+        val askQuote = newCoins(1000, "someotherthing")
+        val bidQuote = newCoins(1000, bidderDenom)
+        val base = newCoins(1000, askerDenom)
+        val askUuid = UUID.randomUUID()
+        val createAsk = CreateAsk.newCoinTrade(
+            id = askUuid.toString(),
+            base = base,
+            quote = askQuote,
+            descriptor = RequestDescriptor(
+                description = "Example description",
+                effectiveTime = OffsetDateTime.now(),
+                attributeRequirement = AttributeRequirement.new(listOf("a.pb", "b.pb"), AttributeRequirementType.NONE),
+            ),
+        )
+        assertSucceeds("Ask should be created without error") {
+            bilateralClient.createAsk(
+                createAsk = createAsk,
+                signer = BilateralAccounts.askerAccount,
+            )
+        }
+        bilateralClient.assertAskExists(askUuid.toString())
+        assertEquals(
+            expected = 0,
+            actual = pbClient.getBalance(BilateralAccounts.askerAccount.address(), askerDenom),
+            message = "The asker account's entire coin balance should be held in escrow after creating an ask",
+        )
+        val bidUuid = UUID.randomUUID()
+        val createBid = CreateBid.newCoinTrade(
+            id = bidUuid.toString(),
+            base = base,
+            quote = bidQuote,
+            descriptor = RequestDescriptor(
+                description = "Example description",
+                effectiveTime = OffsetDateTime.now(),
+                attributeRequirement = AttributeRequirement.new(listOf("c.pb"), AttributeRequirementType.NONE),
+            ),
+        )
+        assertSucceeds("Bid should be created without error") {
+            bilateralClient.createBid(
+                createBid = createBid,
+                signer = BilateralAccounts.bidderAccount,
+            )
+        }
+        bilateralClient.assertBidExists(bidUuid.toString())
+        assertEquals(
+            expected = 0,
+            actual = pbClient.getBalance(BilateralAccounts.bidderAccount.address(), bidderDenom),
+            message = "The bidder account's entire coin balance should be held in escrow after creating a bid",
+        )
+        val executeMatch = ExecuteMatch.new(askUuid.toString(), bidUuid.toString())
+        assertFails("Match should fail because the quotes don't match") {
+            bilateralClient.executeMatch(
+                executeMatch = executeMatch,
+                signer = BilateralAccounts.adminAccount,
+            )
+        }
+        bilateralClient.assertAskExists(askUuid.toString())
+        bilateralClient.assertBidExists(bidUuid.toString())
+        assertSucceeds("Match should succeed because it was manually allowed") {
+            bilateralClient.executeMatch(
+                executeMatch = executeMatch.copy(
+                    executeMatch = executeMatch.executeMatch.copy(acceptMismatchedBids = true)
+                ),
                 signer = BilateralAccounts.adminAccount,
             )
         }

--- a/kotlin-client/src/integrationTest/kotlin/io/provenance/bilateral/contract/MatchReportIntTest.kt
+++ b/kotlin-client/src/integrationTest/kotlin/io/provenance/bilateral/contract/MatchReportIntTest.kt
@@ -5,7 +5,9 @@ import io.provenance.bilateral.execute.CreateBid
 import org.junit.jupiter.api.Test
 import testconfiguration.accounts.BilateralAccounts
 import testconfiguration.functions.assertAskExists
+import testconfiguration.functions.assertAskIsDeleted
 import testconfiguration.functions.assertBidExists
+import testconfiguration.functions.assertBidIsDeleted
 import testconfiguration.functions.newCoins
 import testconfiguration.testcontainers.ContractIntTest
 import java.util.UUID
@@ -66,5 +68,10 @@ class MatchReportIntTest : ContractIntTest() {
             actual = matchReport.errorMessages.isEmpty(),
             message = "The report should not include any error messages, but found: ${matchReport.errorMessages}",
         )
+        // Cleanup outstanding ask and bid
+        bilateralClient.cancelAsk(askId, BilateralAccounts.askerAccount)
+        bilateralClient.assertAskIsDeleted(askId)
+        bilateralClient.cancelBid(bidId, BilateralAccounts.bidderAccount)
+        bilateralClient.assertBidIsDeleted(bidId)
     }
 }

--- a/kotlin-client/src/integrationTest/kotlin/io/provenance/bilateral/contract/MatchReportIntTest.kt
+++ b/kotlin-client/src/integrationTest/kotlin/io/provenance/bilateral/contract/MatchReportIntTest.kt
@@ -1,0 +1,70 @@
+package io.provenance.bilateral.contract
+
+import io.provenance.bilateral.execute.CreateAsk
+import io.provenance.bilateral.execute.CreateBid
+import org.junit.jupiter.api.Test
+import testconfiguration.accounts.BilateralAccounts
+import testconfiguration.functions.assertAskExists
+import testconfiguration.functions.assertBidExists
+import testconfiguration.functions.newCoins
+import testconfiguration.testcontainers.ContractIntTest
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class MatchReportIntTest : ContractIntTest() {
+    @Test
+    fun testSimpleMatchReport() {
+        val askId = UUID.randomUUID().toString()
+        bilateralClient.createAsk(
+            createAsk = CreateAsk.newCoinTrade(
+                id = askId,
+                quote = newCoins(100, "nhash"),
+                base = newCoins(100, "nhash"),
+            ),
+            signer = BilateralAccounts.askerAccount,
+        )
+        bilateralClient.assertAskExists(askId)
+        val bidId = UUID.randomUUID().toString()
+        bilateralClient.createBid(
+            createBid = CreateBid.newCoinTrade(
+                id = bidId,
+                quote = newCoins(100, "nhash"),
+                base = newCoins(100, "nhash"),
+            ),
+            signer = BilateralAccounts.bidderAccount,
+        )
+        bilateralClient.assertBidExists(bidId)
+        val matchReport = bilateralClient.getMatchReport(askId, bidId)
+        assertEquals(
+            expected = askId,
+            actual = matchReport.askId,
+            message = "The ask ids should match",
+        )
+        assertEquals(
+            expected = bidId,
+            actual = matchReport.bidId,
+            message = "The bid ids should match",
+        )
+        assertTrue(
+            actual = matchReport.askExists,
+            message = "The ask should be marked as existing",
+        )
+        assertTrue(
+            actual = matchReport.bidExists,
+            message = "The bid should be marked as existing",
+        )
+        assertTrue(
+            actual = matchReport.standardMatchPossible,
+            message = "The report should indicate that a standard match is possible",
+        )
+        assertTrue(
+            actual = matchReport.quoteMismatchMatchPossible,
+            message = "The report should indicate that a quote mismatch-enabled match is possible",
+        )
+        assertTrue(
+            actual = matchReport.errorMessages.isEmpty(),
+            message = "The report should not include any error messages, but found: ${matchReport.errorMessages}",
+        )
+    }
+}

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/client/BilateralContractClient.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/client/BilateralContractClient.kt
@@ -17,11 +17,13 @@ import io.provenance.bilateral.interfaces.ContractQueryMsg
 import io.provenance.bilateral.models.AskOrder
 import io.provenance.bilateral.models.BidOrder
 import io.provenance.bilateral.models.ContractInfo
+import io.provenance.bilateral.models.MatchReport
 import io.provenance.bilateral.query.ContractSearchResult
 import io.provenance.bilateral.query.GetAsk
 import io.provenance.bilateral.query.GetAskByCollateralId
 import io.provenance.bilateral.query.GetBid
 import io.provenance.bilateral.query.GetContractInfo
+import io.provenance.bilateral.query.GetMatchReport
 import io.provenance.bilateral.query.SearchAsks
 import io.provenance.bilateral.query.SearchBids
 import io.provenance.bilateral.util.ContractAddressResolver
@@ -63,6 +65,10 @@ class BilateralContractClient private constructor(
     fun getBid(id: String): BidOrder = queryContract(GetBid.new(id))
 
     fun getBidOrNull(id: String): BidOrder? = tryOrNull { getBid(id) }
+
+    fun getMatchReport(askId: String, bidId: String): MatchReport = queryContract(GetMatchReport.new(askId, bidId))
+
+    fun getMatchReportOrNull(askId: String, bidId: String): MatchReport? = tryOrNull { getMatchReport(askId, bidId) }
 
     fun searchAsks(searchAsks: SearchAsks): ContractSearchResult<AskOrder> = queryContractWithReference(
         query = searchAsks,

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/execute/ExecuteMatch.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/execute/ExecuteMatch.kt
@@ -8,7 +8,8 @@ import io.provenance.bilateral.interfaces.ContractExecuteMsg
     {
       "execute_match" : {
         "ask_id" : "fe3f6eaf-885f-4ea1-a2fe-a80e2fa745cd",
-        "bid_id" : "c52eeda2-3224-4615-b5f9-e26a4a2f60a6"
+        "bid_id" : "c52eeda2-3224-4615-b5f9-e26a4a2f60a6",
+        "accept_mismatched_bids": true
       }
     }
 
@@ -19,10 +20,29 @@ import io.provenance.bilateral.interfaces.ContractExecuteMsg
  */
 @JsonNaming(SnakeCaseStrategy::class)
 data class ExecuteMatch(val executeMatch: Body) : ContractExecuteMsg {
+    /**
+     * @param askId The unique identifier of the ask to match with.
+     * @param bidId The unique identifier of the bid to match with.
+     * @param acceptMismatchedBids If true, a match will be executed even if the bid offers a lower (or even completely
+     * different denom) coin than was requested in the ask's quote.  Ex: Asker requests 200nhash and bidder offers
+     * 100nhash - refused unless this flag is 'true'.  Ex: Asker requests 200nhash and bidder offers 500000dogecoin -
+     * refused unless this flag is 'true'.
+     */
     @JsonNaming(SnakeCaseStrategy::class)
-    data class Body(val askId: String, val bidId: String)
+    data class Body(val askId: String, val bidId: String, val acceptMismatchedBids: Boolean?)
 
     companion object {
-        fun new(askId: String, bidId: String): ExecuteMatch = ExecuteMatch(executeMatch = Body(askId, bidId))
+        fun new(
+            askId: String,
+            bidId: String,
+            // The contract by default will use 'false' for this value if null is provided
+            acceptMismatchedBids: Boolean? = null,
+        ): ExecuteMatch = ExecuteMatch(
+            executeMatch = Body(
+                askId = askId,
+                bidId = bidId,
+                acceptMismatchedBids = acceptMismatchedBids,
+            )
+        )
     }
 }

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/models/MatchReport.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/models/MatchReport.kt
@@ -1,0 +1,20 @@
+package io.provenance.bilateral.models
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy
+import com.fasterxml.jackson.databind.annotation.JsonNaming
+
+@JsonNaming(SnakeCaseStrategy::class)
+data class MatchReport(
+    val askId: String,
+    val bidId: String,
+    val askExists: Boolean,
+    val bidExists: Boolean,
+    // Indicates that this is a direct match for ask and bid
+    val standardMatchPossible: Boolean,
+    // Indicates that this is a direct match on the base, but the quote is different between ask and bid, and not
+    // exactly what the asker requested - this could be a higher, lower, or completely different bid quote.  The bidder
+    // will still get what the want if this match occurs, so the asker needs to determine if they want what the bidder
+    // is offering
+    val quoteMismatchMatchPossible: Boolean,
+    val errorMessages: List<String>,
+)

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/query/GetMatchReport.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/query/GetMatchReport.kt
@@ -1,0 +1,17 @@
+package io.provenance.bilateral.query
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy
+import com.fasterxml.jackson.databind.annotation.JsonNaming
+import io.provenance.bilateral.interfaces.ContractQueryMsg
+
+@JsonNaming(SnakeCaseStrategy::class)
+data class GetMatchReport(val getMatchReport: Body) : ContractQueryMsg {
+    @JsonNaming(SnakeCaseStrategy::class)
+    data class Body(val askId: String, val bidId: String)
+
+    companion object {
+        fun new(askId: String, bidId: String): GetMatchReport = GetMatchReport(
+            getMatchReport = Body(askId, bidId)
+        )
+    }
+}

--- a/smart-contract/Cargo.lock
+++ b/smart-contract/Cargo.lock
@@ -338,7 +338,7 @@ checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "metadata-bilateral-exchange"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/smart-contract/Cargo.toml
+++ b/smart-contract/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "metadata-bilateral-exchange"
-version = "1.0.0"
-authors = ["Ken Talley <ktalley@figure.com>", "Jake Schwartz <jschwartz@figure.com>"]
+version = "1.0.1"
+authors = ["Jake Schwartz <jschwartz@figure.com>", "Ken Talley <ktalley@figure.com>"]
 edition = "2018"
 
 exclude = [
@@ -26,7 +26,6 @@ overflow-checks = true
 [features]
 # for more explicit tests, cargo test --features=backtraces
 #backtraces = ["cosmwasm-std/backtraces"]
-enable-test-utils = []
 
 [dependencies]
 cosmwasm-std = { version = "=1.0.0", features = ["staking"] }

--- a/smart-contract/Makefile
+++ b/smart-contract/Makefile
@@ -22,7 +22,7 @@ build:
 
 .PHONY: test
 test:
-	@cargo test --features=enable-test-utils
+	@cargo test
 
 .PHONY: schema
 schema:

--- a/smart-contract/examples/schema.rs
+++ b/smart-contract/examples/schema.rs
@@ -9,6 +9,7 @@ use metadata_bilateral_exchange::types::core::msg::{
 };
 use metadata_bilateral_exchange::types::request::ask_types::ask_order::AskOrder;
 use metadata_bilateral_exchange::types::request::bid_types::bid_order::BidOrder;
+use metadata_bilateral_exchange::types::request::match_report::MatchReport;
 
 fn main() {
     let mut out_dir = current_dir().unwrap();
@@ -17,6 +18,7 @@ fn main() {
     remove_schemas(&out_dir).unwrap();
     export_schema(&schema_for!(AskOrder), &out_dir);
     export_schema(&schema_for!(BidOrder), &out_dir);
+    export_schema(&schema_for!(MatchReport), &out_dir);
     export_schema(&schema_for!(ContractInfo), &out_dir);
     export_schema(&schema_for!(ExecuteMsg), &out_dir);
     export_schema(&schema_for!(InstantiateMsg), &out_dir);

--- a/smart-contract/schema/execute_msg.json
+++ b/smart-contract/schema/execute_msg.json
@@ -115,6 +115,12 @@
             "bid_id"
           ],
           "properties": {
+            "accept_mismatched_bids": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
             "ask_id": {
               "type": "string"
             },

--- a/smart-contract/schema/match_report.json
+++ b/smart-contract/schema/match_report.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "MatchReport",
+  "type": "object",
+  "required": [
+    "ask_exists",
+    "ask_id",
+    "bid_exists",
+    "bid_id",
+    "error_messages",
+    "quote_mismatch_match_possible",
+    "standard_match_possible"
+  ],
+  "properties": {
+    "ask_exists": {
+      "type": "boolean"
+    },
+    "ask_id": {
+      "type": "string"
+    },
+    "bid_exists": {
+      "type": "boolean"
+    },
+    "bid_id": {
+      "type": "string"
+    },
+    "error_messages": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "quote_mismatch_match_possible": {
+      "type": "boolean"
+    },
+    "standard_match_possible": {
+      "type": "boolean"
+    }
+  }
+}

--- a/smart-contract/schema/query_msg.json
+++ b/smart-contract/schema/query_msg.json
@@ -25,6 +25,26 @@
     {
       "type": "object",
       "required": [
+        "get_ask_by_collateral_id"
+      ],
+      "properties": {
+        "get_ask_by_collateral_id": {
+          "type": "object",
+          "required": [
+            "collateral_id"
+          ],
+          "properties": {
+            "collateral_id": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
         "get_bid"
       ],
       "properties": {
@@ -35,6 +55,30 @@
           ],
           "properties": {
             "id": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "get_match_report"
+      ],
+      "properties": {
+        "get_match_report": {
+          "type": "object",
+          "required": [
+            "ask_id",
+            "bid_id"
+          ],
+          "properties": {
+            "ask_id": {
+              "type": "string"
+            },
+            "bid_id": {
               "type": "string"
             }
           }

--- a/smart-contract/src/contract.rs
+++ b/smart-contract/src/contract.rs
@@ -9,6 +9,7 @@ use crate::query::get_ask::query_ask;
 use crate::query::get_ask_by_collateral_id::query_ask_by_collateral_id;
 use crate::query::get_bid::query_bid;
 use crate::query::get_contract_info::query_contract_info;
+use crate::query::get_match_report::get_match_report;
 use crate::query::search_asks::search_asks;
 use crate::query::search_bids::search_bids;
 use crate::types::core::error::ContractError;
@@ -40,9 +41,11 @@ pub fn execute(
         ExecuteMsg::CreateBid { bid, descriptor } => create_bid(deps, info, bid, descriptor),
         ExecuteMsg::CancelAsk { id } => cancel_ask(deps, env, info, id),
         ExecuteMsg::CancelBid { id } => cancel_bid(deps, info, id),
-        ExecuteMsg::ExecuteMatch { ask_id, bid_id } => {
-            execute_match(deps, env, info, ask_id, bid_id)
-        }
+        ExecuteMsg::ExecuteMatch {
+            ask_id,
+            bid_id,
+            accept_mismatched_bids,
+        } => execute_match(deps, env, info, ask_id, bid_id, accept_mismatched_bids),
     }
 }
 
@@ -59,6 +62,7 @@ pub fn query(
             query_ask_by_collateral_id(deps, collateral_id)
         }
         QueryMsg::GetBid { id } => query_bid(deps, id),
+        QueryMsg::GetMatchReport { ask_id, bid_id } => get_match_report(deps, ask_id, bid_id),
         QueryMsg::GetContractInfo {} => query_contract_info(deps),
         QueryMsg::SearchAsks { search } => search_asks(deps, search),
         QueryMsg::SearchBids { search } => search_bids(deps, search),

--- a/smart-contract/src/execute/cancel_ask.rs
+++ b/smart-contract/src/execute/cancel_ask.rs
@@ -71,7 +71,6 @@ pub fn cancel_ask(
 }
 
 #[cfg(test)]
-#[cfg(feature = "enable-test-utils")]
 mod tests {
     use super::*;
     use crate::contract::execute;

--- a/smart-contract/src/execute/create_ask.rs
+++ b/smart-contract/src/execute/create_ask.rs
@@ -205,7 +205,6 @@ fn create_scope_trade_ask_collateral(
 }
 
 #[cfg(test)]
-#[cfg(feature = "enable-test-utils")]
 mod tests {
     use super::*;
     use crate::contract::execute;

--- a/smart-contract/src/lib.rs
+++ b/smart-contract/src/lib.rs
@@ -8,5 +8,5 @@ pub mod types;
 pub mod util;
 pub mod validation;
 
-#[cfg(feature = "enable-test-utils")]
+#[cfg(test)]
 pub mod test;

--- a/smart-contract/src/query/get_match_report.rs
+++ b/smart-contract/src/query/get_match_report.rs
@@ -1,0 +1,253 @@
+use crate::storage::ask_order_storage::get_ask_order_by_id;
+use crate::storage::bid_order_storage::get_bid_order_by_id;
+use crate::types::core::error::ContractError;
+use crate::types::request::match_report::MatchReport;
+use crate::validation::execute_match_validation::validate_match;
+use cosmwasm_std::{Binary, Deps};
+use provwasm_std::ProvenanceQuery;
+
+pub fn get_match_report(
+    deps: Deps<ProvenanceQuery>,
+    ask_id: String,
+    bid_id: String,
+) -> Result<Binary, ContractError> {
+    let ask_order_result = get_ask_order_by_id(deps.storage, &ask_id);
+    let bid_order_result = get_bid_order_by_id(deps.storage, &bid_id);
+    if ask_order_result.is_err() || bid_order_result.is_err() {
+        return MatchReport::new_missing_order(
+            ask_id,
+            bid_id,
+            ask_order_result.is_ok(),
+            bid_order_result.is_ok(),
+        )?
+        .to_binary();
+    }
+    let ask_order = ask_order_result.unwrap();
+    let bid_order = bid_order_result.unwrap();
+    let standard_match_result = validate_match(&deps, &ask_order, &bid_order, false);
+    let quote_mismatch_result = validate_match(&deps, &ask_order, &bid_order, true);
+    let mut error_messages = vec![];
+    if let Err(e) = &standard_match_result {
+        error_messages.push(format!("Standard match fails due to: {:?}", e))
+    }
+    if let Err(e) = &quote_mismatch_result {
+        error_messages.push(format!(
+            "Quote mismatch-enabled match fails due to: {:?}",
+            e
+        ))
+    }
+    MatchReport::new_existing_orders(
+        ask_id,
+        bid_id,
+        standard_match_result.is_ok(),
+        quote_mismatch_result.is_ok(),
+        &error_messages,
+    )
+    .to_binary()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::query::get_match_report::get_match_report;
+    use crate::storage::ask_order_storage::insert_ask_order;
+    use crate::storage::bid_order_storage::insert_bid_order;
+    use crate::test::cosmos_type_helpers::MockOwnedDeps;
+    use crate::test::mock_scope::DEFAULT_SCOPE_ID;
+    use crate::test::request_helpers::{mock_ask_order, mock_bid_order, mock_bid_scope_trade};
+    use crate::types::request::ask_types::ask_collateral::AskCollateral;
+    use crate::types::request::bid_types::bid_collateral::BidCollateral;
+    use crate::types::request::match_report::MatchReport;
+    use cosmwasm_std::{coins, from_binary};
+    use provwasm_mocks::mock_dependencies;
+
+    #[test]
+    fn test_missing_orders_report() {
+        let mut deps = mock_dependencies(&[]);
+        let missing_both_report = deserialize_report(&deps, "ask_id", "bid_id");
+        assert!(
+            !missing_both_report.ask_exists,
+            "the ask should not be marked as existing",
+        );
+        assert!(
+            !missing_both_report.bid_exists,
+            "the bid should not be marked as existing",
+        );
+        assert_report_includes_single_error(
+            &missing_both_report,
+            "AskOrder [ask_id] and BidOrder [bid_id] were missing from contract storage",
+        );
+        let ask_order = mock_ask_order(AskCollateral::coin_trade(&[], &[]));
+        insert_ask_order(deps.as_mut().storage, &ask_order)
+            .expect("expected the ask order to be inserted");
+        let bid_order = mock_bid_order(BidCollateral::coin_trade(&[], &[]));
+        insert_bid_order(deps.as_mut().storage, &bid_order)
+            .expect("expected the bid order to be inserted");
+        let missing_ask_report = deserialize_report(&deps, "not_ask", "bid_id");
+        assert!(
+            !missing_ask_report.ask_exists,
+            "the ask should not be marked as existing"
+        );
+        assert!(
+            missing_ask_report.bid_exists,
+            "the bid should be marked as existing"
+        );
+        assert_report_includes_single_error(
+            &missing_ask_report,
+            "AskOrder [not_ask] was missing from contract storage",
+        );
+        let missing_bid_report = deserialize_report(&deps, "ask_id", "not_bid");
+        assert!(
+            missing_bid_report.ask_exists,
+            "the ask should be marked as existing",
+        );
+        assert!(
+            !missing_bid_report.bid_exists,
+            "the bid should not be marked as existing",
+        );
+        assert_report_includes_single_error(
+            &missing_bid_report,
+            "BidOrder [not_bid] was missing from contract storage",
+        );
+    }
+
+    #[test]
+    fn test_standard_match_failure_only() {
+        let mut deps = mock_dependencies(&[]);
+        let base = coins(100, "base");
+        let ask_order = mock_ask_order(AskCollateral::coin_trade(&base, &coins(100, "quote")));
+        insert_ask_order(deps.as_mut().storage, &ask_order).expect("ask should be inserted");
+        let bid_order = mock_bid_order(BidCollateral::coin_trade(&base, &coins(99, "quote")));
+        insert_bid_order(deps.as_mut().storage, &bid_order).expect("bid should be inserted");
+        let report = deserialize_report(&deps, "ask_id", "bid_id");
+        assert!(report.ask_exists, "the ask should be marked as existing",);
+        assert!(report.bid_exists, "the bid should be marked as existing",);
+        assert!(
+            !report.standard_match_possible,
+            "the standard match possible report param should indicate false",
+        );
+        assert!(
+            report.quote_mismatch_match_possible,
+            "the quote mismatch match possible report param should indicate true",
+        );
+        assert_eq!(
+            1,
+            report.error_messages.len(),
+            "the report should have a single error message",
+        );
+        assert!(
+            report
+                .error_messages
+                .first()
+                .unwrap()
+                .contains("Standard match fails due to"),
+            "the failing message should indicate the reason for the mismatched standard match",
+        );
+    }
+
+    #[test]
+    fn test_both_match_types_failure() {
+        let mut deps = mock_dependencies(&[]);
+        let ask_order = mock_ask_order(AskCollateral::coin_trade(
+            &coins(100, "base"),
+            &coins(100, "quote"),
+        ));
+        insert_ask_order(deps.as_mut().storage, &ask_order).expect("ask should be inserted");
+        let bid_order =
+            mock_bid_order(mock_bid_scope_trade(DEFAULT_SCOPE_ID, &coins(100, "quote")));
+        insert_bid_order(deps.as_mut().storage, &bid_order).expect("bid should be inserted");
+        let report = deserialize_report(&deps, "ask_id", "bid_id");
+        assert!(report.ask_exists, "the ask should be marked as existing");
+        assert!(report.bid_exists, "the bid should be marked as existing");
+        assert!(
+            !report.standard_match_possible,
+            "the standard match possible report param should indicate false",
+        );
+        assert!(
+            !report.quote_mismatch_match_possible,
+            "the quote mismatch match possible report param should indicate false",
+        );
+        assert_eq!(
+            2,
+            report.error_messages.len(),
+            "the report should include two error messages",
+        );
+        assert!(
+            report
+                .error_messages
+                .iter()
+                .any(|message| message.contains("Standard match fails due to")),
+            "a message should indicate the reason that a standard match cannot be completed",
+        );
+        assert!(
+            report
+                .error_messages
+                .iter()
+                .any(|message| message.contains("Quote mismatch-enabled match fails due to")),
+            "a message should indicate the reason that a quote mismatch match cannot be completed",
+        );
+    }
+
+    #[test]
+    fn test_successful_match_report() {
+        let mut deps = mock_dependencies(&[]);
+        let base = coins(100, "base");
+        let quote = coins(100, "quote");
+        let ask_order = mock_ask_order(AskCollateral::coin_trade(&base, &quote));
+        insert_ask_order(deps.as_mut().storage, &ask_order).expect("ask should be inserted");
+        let bid_order = mock_bid_order(BidCollateral::coin_trade(&base, &quote));
+        insert_bid_order(deps.as_mut().storage, &bid_order).expect("bid should be inserted");
+        let report = deserialize_report(&deps, "ask_id", "bid_id");
+        assert!(report.ask_exists, "the ask should be marked as existing");
+        assert!(report.bid_exists, "the bid should be marked as existing");
+        assert!(
+            report.standard_match_possible,
+            "the report should indicate that a standard match is possible",
+        );
+        assert!(
+            report.quote_mismatch_match_possible,
+            "the report should indicate that a quote mismatch match is possible",
+        );
+        assert!(
+            report.error_messages.is_empty(),
+            "the report should not include any error messages",
+        );
+    }
+
+    fn deserialize_report<A: Into<String>, B: Into<String>>(
+        deps: &MockOwnedDeps,
+        ask_id: A,
+        bid_id: B,
+    ) -> MatchReport {
+        let ask_id = ask_id.into();
+        let bid_id = bid_id.into();
+        let binary = get_match_report(deps.as_ref(), ask_id.clone(), bid_id.clone())
+            .expect("expected a report to be produced");
+        let report = from_binary::<MatchReport>(&binary)
+            .expect("expected the binary to deserialize to a match report");
+        assert_eq!(
+            ask_id, report.ask_id,
+            "sanity check: ask id should match the input value",
+        );
+        assert_eq!(
+            bid_id, report.bid_id,
+            "sanity check: bid id should match the input value",
+        );
+        report
+    }
+
+    fn assert_report_includes_single_error<S: Into<String>>(
+        report: &MatchReport,
+        expected_error_message: S,
+    ) {
+        assert_eq!(
+            1,
+            report.error_messages.len(),
+            "expected only a single error message to be included in the match report",
+        );
+        assert_eq!(
+            &expected_error_message.into(),
+            report.error_messages.first().unwrap(),
+            "expected the error message in the report to be the correct text",
+        );
+    }
+}

--- a/smart-contract/src/query/mod.rs
+++ b/smart-contract/src/query/mod.rs
@@ -2,5 +2,6 @@ pub mod get_ask;
 pub mod get_ask_by_collateral_id;
 pub mod get_bid;
 pub mod get_contract_info;
+pub mod get_match_report;
 pub mod search_asks;
 pub mod search_bids;

--- a/smart-contract/src/test/cosmos_type_helpers.rs
+++ b/smart-contract/src/test/cosmos_type_helpers.rs
@@ -1,4 +1,9 @@
-use cosmwasm_std::Response;
+use cosmwasm_std::testing::{MockApi, MockStorage};
+use cosmwasm_std::{OwnedDeps, Response};
+use provwasm_mocks::ProvenanceMockQuerier;
+use provwasm_std::ProvenanceQuery;
+
+pub type MockOwnedDeps = OwnedDeps<MockStorage, MockApi, ProvenanceMockQuerier, ProvenanceQuery>;
 
 pub fn single_attribute_for_key<'a, T>(response: &'a Response<T>, key: &'a str) -> &'a str {
     response

--- a/smart-contract/src/types/core/msg.rs
+++ b/smart-contract/src/types/core/msg.rs
@@ -32,6 +32,7 @@ pub enum ExecuteMsg {
     ExecuteMatch {
         ask_id: String,
         bid_id: String,
+        accept_mismatched_bids: Option<bool>,
     },
 }
 
@@ -41,6 +42,7 @@ pub enum QueryMsg {
     GetAsk { id: String },
     GetAskByCollateralId { collateral_id: String },
     GetBid { id: String },
+    GetMatchReport { ask_id: String, bid_id: String },
     GetContractInfo {},
     SearchAsks { search: Search },
     SearchBids { search: Search },

--- a/smart-contract/src/types/request/match_report.rs
+++ b/smart-contract/src/types/request/match_report.rs
@@ -1,0 +1,75 @@
+use crate::types::core::error::ContractError;
+use crate::util::extensions::ResultExtensions;
+use cosmwasm_std::{to_binary, Binary};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct MatchReport {
+    pub ask_id: String,
+    pub bid_id: String,
+    pub ask_exists: bool,
+    pub bid_exists: bool,
+    pub standard_match_possible: bool,
+    pub quote_mismatch_match_possible: bool,
+    pub error_messages: Vec<String>,
+}
+impl MatchReport {
+    pub fn new_missing_order<A: Into<String>, B: Into<String>>(
+        ask_id: A,
+        bid_id: B,
+        ask_exists: bool,
+        bid_exists: bool,
+    ) -> Result<Self, ContractError> {
+        let ask_id = ask_id.into();
+        let bid_id = bid_id.into();
+        let error_message = if ask_exists && bid_exists {
+            return ContractError::validation_error(&["created missing order MatchReport with both ask and bid existing. this is a contract bug"]).to_err();
+        } else if ask_exists {
+            format!("BidOrder [{}] was missing from contract storage", &bid_id)
+        } else if bid_exists {
+            format!("AskOrder [{}] was missing from contract storage", &ask_id)
+        } else {
+            format!(
+                "AskOrder [{}] and BidOrder [{}] were missing from contract storage",
+                &ask_id, &bid_id
+            )
+        };
+        Self {
+            ask_id,
+            bid_id,
+            ask_exists,
+            bid_exists,
+            standard_match_possible: false,
+            quote_mismatch_match_possible: false,
+            error_messages: vec![error_message],
+        }
+        .to_ok()
+    }
+
+    pub fn new_existing_orders<A: Into<String>, B: Into<String>, E: Into<String>>(
+        ask_id: A,
+        bid_id: B,
+        standard_match_possible: bool,
+        quote_mismatch_match_possible: bool,
+        error_messages: &[E],
+    ) -> Self
+    where
+        E: Clone,
+    {
+        Self {
+            ask_id: ask_id.into(),
+            bid_id: bid_id.into(),
+            ask_exists: true,
+            bid_exists: true,
+            standard_match_possible,
+            quote_mismatch_match_possible,
+            error_messages: error_messages.iter().cloned().map(|s| s.into()).collect(),
+        }
+    }
+
+    pub fn to_binary(&self) -> Result<Binary, ContractError> {
+        to_binary(self)?.to_ok()
+    }
+}

--- a/smart-contract/src/types/request/mod.rs
+++ b/smart-contract/src/types/request/mod.rs
@@ -1,5 +1,6 @@
 pub mod ask_types;
 pub mod bid_types;
+pub mod match_report;
 pub mod request_descriptor;
 pub mod request_type;
 pub mod search;

--- a/smart-contract/src/util/provenance_utilities.rs
+++ b/smart-contract/src/util/provenance_utilities.rs
@@ -164,7 +164,6 @@ pub fn replace_scope_owner(mut scope: Scope, new_owner: Addr) -> Scope {
 }
 
 #[cfg(test)]
-#[cfg(feature = "enable-test-utils")]
 mod tests {
     use super::*;
     use crate::test::mock_marker::MockMarker;

--- a/smart-contract/src/validation/ask_order_validation.rs
+++ b/smart-contract/src/validation/ask_order_validation.rs
@@ -245,7 +245,6 @@ pub fn validate_ask_order(ask_order: &AskOrder) -> Result<(), ContractError> {
 }
 
 #[cfg(test)]
-#[cfg(feature = "enable-test-utils")]
 mod tests {
     use crate::test::request_helpers::{
         mock_ask_marker_share_multi, mock_ask_marker_share_single, mock_ask_marker_trade,

--- a/smart-contract/src/validation/bid_order_validation.rs
+++ b/smart-contract/src/validation/bid_order_validation.rs
@@ -184,7 +184,6 @@ pub fn validate_bid_order(bid_order: &BidOrder) -> Result<(), ContractError> {
 }
 
 #[cfg(test)]
-#[cfg(feature = "enable-test-utils")]
 mod tests {
     use crate::test::request_helpers::{
         mock_bid_marker_share, mock_bid_marker_trade, mock_bid_order, mock_bid_scope_trade,

--- a/smart-contract/src/validation/marker_exchange_validation.rs
+++ b/smart-contract/src/validation/marker_exchange_validation.rs
@@ -49,7 +49,6 @@ pub fn validate_marker_for_ask(
 }
 
 #[cfg(test)]
-#[cfg(feature = "enable-test-utils")]
 mod tests {
     use crate::test::mock_marker::{MockMarker, DEFAULT_MARKER_DENOM};
     use crate::types::core::error::ContractError;


### PR DESCRIPTION
# Features
- Adds the ability to generate `MatchReport` values with a contract query.  This lets the caller know if both the ask and bid exist, whether or not they can match in different circumstances, and denotes any errors that are preventing matches.
- Adds a new flag `accept_mismatched_bids` to the `ExecuteMatch` msg.  If set to `true`, the match will still execute if the bidder's quote does not match the asker's requested quote.
- Adds the ability for the asker to execute a match.  Given the bidder will always get what they ask for without exception, this is safe for all parties involved.

# Changes
- Removes `enable-test-utils` feature in `Cargo.toml`.  I realized that I could just put `#[cfg(test)]` over test-only mods and the code will still compile correctly.
- Now that the quotes may not match, I had to shuffle the values around for the bank send messages in the `execute_match` file.  The asker was always receiving its own declared quote, which is no longer the amount of funds that should be sent when the bid can be wholly different.
- Execute match validation now accepts an immutable `Deps<ProvenanceQuery>` reference instead of a mutable reference.  This is because it never needed a mutable reference, and having that available in the validation was unsafe, anyhow.