### PR TITLE
v1.0.3: Share sale revamp + terminology tweaks

### DIFF
--- a/kotlin-client/src/integrationTest/kotlin/io/provenance/bilateral/contract/MarkerShareSaleIntTest.kt
+++ b/kotlin-client/src/integrationTest/kotlin/io/provenance/bilateral/contract/MarkerShareSaleIntTest.kt
@@ -60,9 +60,10 @@ class MarkerShareSaleIntTest : ContractIntTest() {
         val askUuid = UUID.randomUUID()
         val createAsk = CreateAsk.newMarkerShareSale(
             id = askUuid.toString(),
-            denom = markerDenom,
+            markerDenom = markerDenom,
+            sharesToSell = shareSaleAmount.toString(),
             quotePerShare = newCoins(1, bidderDenom),
-            shareSaleType = ShareSaleType.single(shareSaleAmount.toString()),
+            shareSaleType = ShareSaleType.SINGLE_TRANSACTION,
             descriptor = RequestDescriptor("Example description", OffsetDateTime.now())
         )
         bilateralClient.createAsk(createAsk, BilateralAccounts.askerAccount)
@@ -76,9 +77,10 @@ class MarkerShareSaleIntTest : ContractIntTest() {
             bilateralClient.createAsk(
                 createAsk = CreateAsk.newMarkerShareSale(
                     id = UUID.randomUUID().toString(),
-                    denom = markerDenom,
+                    markerDenom = markerDenom,
+                    sharesToSell = shareSaleAmount.toString(),
                     quotePerShare = newCoins(1, bidderDenom),
-                    shareSaleType = ShareSaleType.single(shareSaleAmount.toString()),
+                    shareSaleType = ShareSaleType.SINGLE_TRANSACTION,
                 ),
                 signer = BilateralAccounts.askerAccount,
             )
@@ -86,7 +88,7 @@ class MarkerShareSaleIntTest : ContractIntTest() {
         val bidUuid = UUID.randomUUID()
         val createBid = CreateBid.newMarkerShareSale(
             id = bidUuid.toString(),
-            denom = markerDenom,
+            markerDenom = markerDenom,
             shareCount = shareSaleAmount.toString(),
             quote = newCoins(50, bidderDenom),
             descriptor = RequestDescriptor("Example description", OffsetDateTime.now())
@@ -164,9 +166,10 @@ class MarkerShareSaleIntTest : ContractIntTest() {
         val askUuid = UUID.randomUUID()
         val createAsk = CreateAsk.newMarkerShareSale(
             id = askUuid.toString(),
-            denom = markerDenom,
+            markerDenom = markerDenom,
+            sharesToSell = shareCount.minus(shareCutoff).toString(),
             quotePerShare = newCoins(1, bidderDenom),
-            shareSaleType = ShareSaleType.multiple(removeSaleShareThreshold = shareCutoff.toString()),
+            shareSaleType = ShareSaleType.MULTIPLE_TRANSACTIONS,
             descriptor = RequestDescriptor("Example description", OffsetDateTime.now())
         )
         bilateralClient.createAsk(
@@ -186,7 +189,7 @@ class MarkerShareSaleIntTest : ContractIntTest() {
             val bidUuid = UUID.randomUUID()
             val createBid = CreateBid.newMarkerShareSale(
                 id = bidUuid.toString(),
-                denom = markerDenom,
+                markerDenom = markerDenom,
                 shareCount = sharePurchaseCount.toString(),
                 // Pay 1 bidderDenom per share
                 quote = newCoins(sharePurchaseCount, bidderDenom),
@@ -255,9 +258,10 @@ class MarkerShareSaleIntTest : ContractIntTest() {
         val askUuid = UUID.randomUUID()
         val createAsk = CreateAsk.newMarkerShareSale(
             id = askUuid.toString(),
-            denom = markerDenom,
+            markerDenom = markerDenom,
+            sharesToSell = 100.toString(),
             quotePerShare = newCoins(100, "nhash"),
-            shareSaleType = ShareSaleType.single(100.toString()),
+            shareSaleType = ShareSaleType.SINGLE_TRANSACTION,
         )
         assertFails("An ask cannot be created when the contract does not have admin and withdraw permissions on the marker") {
             bilateralClient.createAsk(createAsk, BilateralAccounts.askerAccount)
@@ -298,9 +302,10 @@ class MarkerShareSaleIntTest : ContractIntTest() {
             bilateralClient.createAsk(
                 createAsk = CreateAsk.newMarkerShareSale(
                     id = UUID.randomUUID().toString(),
-                    denom = markerDenom,
+                    markerDenom = markerDenom,
+                    sharesToSell = 100.toString(),
                     quotePerShare = newCoins(1, "nhash"),
-                    shareSaleType = ShareSaleType.single(100.toString()),
+                    shareSaleType = ShareSaleType.SINGLE_TRANSACTION,
                 ),
                 signer = BilateralAccounts.askerAccount,
             )
@@ -332,7 +337,7 @@ class MarkerShareSaleIntTest : ContractIntTest() {
         val bidUuid = UUID.randomUUID()
         val createBid = CreateBid.newMarkerShareSale(
             id = bidUuid.toString(),
-            denom = bidderDenom,
+            markerDenom = bidderDenom,
             shareCount = 100.toString(),
             quote = newCoins(100, bidderDenom),
         )

--- a/kotlin-client/src/integrationTest/kotlin/io/provenance/bilateral/contract/MarkerShareSaleIntTest.kt
+++ b/kotlin-client/src/integrationTest/kotlin/io/provenance/bilateral/contract/MarkerShareSaleIntTest.kt
@@ -140,7 +140,7 @@ class MarkerShareSaleIntTest : ContractIntTest() {
         val markerDenom = "multipletx"
         val shareCount = 100L
         val sharePurchaseCount = 25L
-        val shareCutoff = 25L
+        val sharesToSell = 75L
         val markerPermissions = listOf(Access.ACCESS_ADMIN, Access.ACCESS_DEPOSIT, Access.ACCESS_DELETE)
         createMarker(
             pbClient = pbClient,
@@ -167,7 +167,7 @@ class MarkerShareSaleIntTest : ContractIntTest() {
         val createAsk = CreateAsk.newMarkerShareSale(
             id = askUuid.toString(),
             markerDenom = markerDenom,
-            sharesToSell = shareCount.minus(shareCutoff).toString(),
+            sharesToSell = sharesToSell.toString(),
             quotePerShare = newCoins(1, bidderDenom),
             shareSaleType = ShareSaleType.MULTIPLE_TRANSACTIONS,
             descriptor = RequestDescriptor("Example description", OffsetDateTime.now())
@@ -182,7 +182,7 @@ class MarkerShareSaleIntTest : ContractIntTest() {
             actual = pbClient.getMarkerAccount(markerDenom).accessControlList.assertSingle("Expected only a single access control list to exist after creating a share sale").address,
             message = "The contract should be the sole owner of the marker during the share sale",
         )
-        val maxIteration = (shareCount - shareCutoff) / sharePurchaseCount - 1
+        val maxIteration = sharesToSell / sharePurchaseCount - 1
         var expectedBidderMarkerHoldings = 0L
         var expectedAskerDenomHoldings = 0L
         for (counter in 0..maxIteration) {

--- a/kotlin-client/src/integrationTest/kotlin/io/provenance/bilateral/contract/MarkerTradeIntTest.kt
+++ b/kotlin-client/src/integrationTest/kotlin/io/provenance/bilateral/contract/MarkerTradeIntTest.kt
@@ -54,7 +54,7 @@ class MarkerTradeIntTest : ContractIntTest() {
         val askUuid = UUID.randomUUID()
         val createAsk = CreateAsk.newMarkerTrade(
             id = askUuid.toString(),
-            denom = markerDenom,
+            markerDenom = markerDenom,
             quotePerShare = newCoins(15, bidderDenom),
             descriptor = RequestDescriptor(description = "Example description", effectiveTime = OffsetDateTime.now()),
         )
@@ -70,7 +70,7 @@ class MarkerTradeIntTest : ContractIntTest() {
         val bidUuid = UUID.randomUUID()
         val createBid = CreateBid.newMarkerTrade(
             id = bidUuid.toString(),
-            denom = markerDenom,
+            markerDenom = markerDenom,
             quote = newCoins(150, bidderDenom),
             descriptor = RequestDescriptor(description = "Example description", effectiveTime = OffsetDateTime.now()),
         )
@@ -125,7 +125,7 @@ class MarkerTradeIntTest : ContractIntTest() {
         val askUuid = UUID.randomUUID()
         val createAsk = CreateAsk.newMarkerTrade(
             id = askUuid.toString(),
-            denom = markerDenom,
+            markerDenom = markerDenom,
             quotePerShare = newCoins(10, "nhash"),
         )
         assertFails("When the contract is not an admin on the marker, creating the ask should fail") {
@@ -145,7 +145,7 @@ class MarkerTradeIntTest : ContractIntTest() {
             bilateralClient.createAsk(
                 createAsk = CreateAsk.newMarkerTrade(
                     id = UUID.randomUUID().toString(),
-                    denom = markerDenom,
+                    markerDenom = markerDenom,
                     quotePerShare = newCoins(150, "nhash"),
                 ),
                 signer = BilateralAccounts.askerAccount,
@@ -183,7 +183,7 @@ class MarkerTradeIntTest : ContractIntTest() {
         val bidUuid = UUID.randomUUID()
         val createBid = CreateBid.newMarkerTrade(
             id = bidUuid.toString(),
-            denom = bidderDenom,
+            markerDenom = bidderDenom,
             quote = newCoins(99, bidderDenom),
         )
         bilateralClient.createBid(createBid, BilateralAccounts.bidderAccount)

--- a/kotlin-client/src/integrationTest/kotlin/io/provenance/bilateral/contract/MatchReportIntTest.kt
+++ b/kotlin-client/src/integrationTest/kotlin/io/provenance/bilateral/contract/MatchReportIntTest.kt
@@ -11,10 +11,13 @@ import testconfiguration.functions.assertBidIsDeleted
 import testconfiguration.functions.newCoins
 import testconfiguration.testcontainers.ContractIntTest
 import java.util.UUID
+import kotlin.test.Ignore
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class MatchReportIntTest : ContractIntTest() {
+    // TODO: Stop ignoring this test once match reports are no longer disabled (in v1.0.4)
+    @Ignore
     @Test
     fun testSimpleMatchReport() {
         val askId = UUID.randomUUID().toString()

--- a/kotlin-client/src/integrationTest/resources/scripts/build-smart-contract.sh
+++ b/kotlin-client/src/integrationTest/resources/scripts/build-smart-contract.sh
@@ -3,17 +3,19 @@ wasm_output_directory=./../smart-contract/artifacts/
 wasm_directory=./src/integrationTest/resources/artifacts
 wasm_file="$wasm_directory/metadata_bilateral_exchange.wasm"
 if test -f "$wasm_file"; then
-  echo "Contract WASM already exists. Skipping generation"
+  echo "Removing old WASM file"
+  rm "$wasm_file"
+  echo "Successfully removed old wasm file.  Regenerating it now..."
 else
-  echo "Contract WASM does not currently exist. Generating it..."
-  (cd ./../smart-contract && make optimize)
-  if test -f "$wasm_directory"; then
-    echo "WASM project output directory already exists. No need to create it"
-  else
-    echo "Creating WASM output directory: $wasm_directory"
-    mkdir "$wasm_directory"
-  fi
-  echo "Copying WASM file to output directory: $wasm_directory"
-  cp "$wasm_output_directory/metadata_bilateral_exchange.wasm" "$wasm_file"
+  echo "Generating WASM file for testing..."
 fi
+(cd ./../smart-contract && make optimize)
+if test -f "$wasm_directory"; then
+  echo "WASM project output directory already exists. No need to create it"
+else
+  echo "Creating WASM output directory: $wasm_directory"
+  mkdir "$wasm_directory"
+fi
+echo "Copying WASM file to output directory: $wasm_directory"
+cp "$wasm_output_directory/metadata_bilateral_exchange.wasm" "$wasm_file"
 

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/execute/CreateAsk.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/execute/CreateAsk.kt
@@ -39,11 +39,11 @@ data class CreateAsk(
          */
         fun newMarkerTrade(
             id: String,
-            denom: String,
+            markerDenom: String,
             quotePerShare: List<Coin>,
             descriptor: RequestDescriptor? = null,
         ): CreateAsk = CreateAsk(
-            ask = MarkerTradeAsk(id, denom, quotePerShare),
+            ask = MarkerTradeAsk(id, markerDenom, quotePerShare),
             descriptor = descriptor,
         )
 
@@ -57,12 +57,13 @@ data class CreateAsk(
          */
         fun newMarkerShareSale(
             id: String,
-            denom: String,
+            markerDenom: String,
+            sharesToSell: String,
             quotePerShare: List<Coin>,
             shareSaleType: ShareSaleType,
             descriptor: RequestDescriptor? = null,
         ): CreateAsk = CreateAsk(
-            ask = MarkerShareSaleAsk(id, denom, quotePerShare, shareSaleType),
+            ask = MarkerShareSaleAsk(id, markerDenom, sharesToSell, quotePerShare, shareSaleType),
             descriptor = descriptor,
         )
 
@@ -129,7 +130,7 @@ sealed interface Ask {
     @JsonTypeName("marker_trade")
     data class MarkerTradeAsk(
         val id: String,
-        val denom: String,
+        val markerDenom: String,
         val quotePerShare: List<Coin>,
     ) : Ask
 
@@ -137,7 +138,8 @@ sealed interface Ask {
     @JsonTypeName("marker_share_sale")
     data class MarkerShareSaleAsk(
         val id: String,
-        val denom: String,
+        val markerDenom: String,
+        val sharesToSell: String,
         val quotePerShare: List<Coin>,
         val shareSaleType: ShareSaleType,
     ) : Ask

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/execute/CreateBid.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/execute/CreateBid.kt
@@ -35,13 +35,13 @@ data class CreateBid(val bid: Bid, val descriptor: RequestDescriptor?) : Contrac
 
         fun newMarkerTrade(
             id: String,
-            denom: String,
+            markerDenom: String,
             quote: List<Coin>,
             descriptor: RequestDescriptor? = null,
         ): CreateBid = CreateBid(
             bid = MarkerTradeBid(
                 id = id,
-                denom = denom,
+                markerDenom = markerDenom,
                 quote = quote,
             ),
             descriptor = descriptor,
@@ -49,14 +49,14 @@ data class CreateBid(val bid: Bid, val descriptor: RequestDescriptor?) : Contrac
 
         fun newMarkerShareSale(
             id: String,
-            denom: String,
+            markerDenom: String,
             shareCount: String,
             quote: List<Coin>,
             descriptor: RequestDescriptor? = null,
         ): CreateBid = CreateBid(
             bid = MarkerShareSaleBid(
                 id = id,
-                denom = denom,
+                markerDenom = markerDenom,
                 shareCount = shareCount,
                 quote = quote,
             ),
@@ -126,7 +126,7 @@ sealed interface Bid {
     @JsonTypeName("marker_trade")
     data class MarkerTradeBid(
         val id: String,
-        val denom: String,
+        val markerDenom: String,
         // The quote is used for funds, and never added to the json payload send to the contract
         @JsonIgnore
         val quote: List<Coin>,
@@ -136,7 +136,7 @@ sealed interface Bid {
     @JsonTypeName("marker_share_sale")
     data class MarkerShareSaleBid(
         val id: String,
-        val denom: String,
+        val markerDenom: String,
         val shareCount: String,
         // The quote is used for funds, and never added to the json payload send to the contract
         @JsonIgnore

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/models/AskOrder.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/models/AskOrder.kt
@@ -2,6 +2,7 @@ package io.provenance.bilateral.models
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.fasterxml.jackson.annotation.JsonTypeName
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy
 import com.fasterxml.jackson.databind.annotation.JsonNaming
 import cosmos.base.v1beta1.CoinOuterClass.Coin
@@ -20,216 +21,54 @@ data class AskOrder(
 ) {
     @JsonIgnore
     fun <T> mapCollateral(
-        coinTrade: (coinTrade: CoinTrade.Body) -> T,
-        markerTrade: (markerTrade: MarkerTrade.Body) -> T,
-        markerShareSale: (markerShareSale: MarkerShareSale.Body) -> T,
-        scopeTrade: (scopeTrade: ScopeTrade.Body) -> T,
-    ): T = when (this.collateral) {
-        is CoinTrade -> coinTrade(this.collateral.coinTrade)
-        is MarkerTrade -> markerTrade(this.collateral.markerTrade)
-        is MarkerShareSale -> markerShareSale(this.collateral.markerShareSale)
-        is ScopeTrade -> scopeTrade(this.collateral.scopeTrade)
+        coinTrade: (coinTrade: CoinTrade) -> T,
+        markerTrade: (markerTrade: MarkerTrade) -> T,
+        markerShareSale: (markerShareSale: MarkerShareSale) -> T,
+        scopeTrade: (scopeTrade: ScopeTrade) -> T,
+    ): T = when (collateral) {
+        is CoinTrade -> coinTrade(collateral)
+        is MarkerTrade -> markerTrade(collateral)
+        is MarkerShareSale -> markerShareSale(collateral)
+        is ScopeTrade -> scopeTrade(collateral)
     }
 }
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION)
+@JsonTypeInfo(include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.NAME)
 sealed interface AskCollateral {
-    /*
-        {
-          "id" : "fe3f6eaf-885f-4ea1-a2fe-a80e2fa745cd",
-          "ask_type" : "coin_trade",
-          "owner" : "tp1yc4qpessmkxzc287te08kdku9gvta27fgr8m8y",
-          "collateral" : {
-            "coin_trade" : {
-              "base" : [ {
-                "denom" : "nhash",
-                "amount" : "50"
-              } ],
-              "quote" : [ {
-                "denom" : "nhash",
-                "amount" : "100"
-              } ]
-            }
-          },
-          "descriptor" : {
-            "description" : "Example description",
-            "effective_time" : "1655690320315894000",
-            "attribute_requirement" : {
-              "attributes" : [ "a.pb", "b.pio" ],
-              "requirement_type" : "all"
-            }
-          }
-        }
-     */
     @JsonNaming(SnakeCaseStrategy::class)
-    data class CoinTrade(val coinTrade: Body) : AskCollateral {
-        @JsonNaming(SnakeCaseStrategy::class)
-        data class Body(
-            val base: List<Coin>,
-            val quote: List<Coin>,
-        )
-    }
+    @JsonTypeName("coin_trade")
+    data class CoinTrade(
+        val base: List<Coin>,
+        val quote: List<Coin>,
+    ) : AskCollateral
 
-    /*
-        {
-          "id" : "99ba4102-53b8-4d73-8096-e7194ac78604",
-          "ask_type" : "marker_trade",
-          "owner" : "tp1yc4qpessmkxzc287te08kdku9gvta27fgr8m8y",
-          "collateral" : {
-            "marker_trade" : {
-              "address" : "tp1p3sl9tll0ygj3flwt5r2w0n6fx9p5ngqswjn5k",
-              "denom" : "testcoin",
-              "quote_per_share" : [ {
-                "denom" : "nhash",
-                "amount" : "50"
-              } ],
-              "removed_permissions" : [ {
-                "address" : "tp1yc4qpessmkxzc287te08kdku9gvta27fgr8m8y",
-                "permissions" : [ "admin", "deposit", "withdraw", "burn", "mint", "delete" ]
-              } ]
-            }
-          },
-          "descriptor" : {
-            "description" : "Example description",
-            "effective_time" : "1655690830145197000",
-            "attribute_requirement" : {
-              "attributes" : [ "attr.sc.pb", "other.pio" ],
-              "requirement_type" : "any"
-            }
-          }
-        }
-     */
     @JsonNaming(SnakeCaseStrategy::class)
-    data class MarkerTrade(val markerTrade: Body) : AskCollateral {
-        @JsonNaming(SnakeCaseStrategy::class)
-        data class Body(
-            val address: String,
-            val denom: String,
-            val quotePerShare: List<Coin>,
-            val removedPermissions: List<MarkerAccessGrant>,
-        )
-    }
+    @JsonTypeName("marker_trade")
+    data class MarkerTrade(
+        val markerAddress: String,
+        val markerDenom: String,
+        val quotePerShare: List<Coin>,
+        val removedPermissions: List<MarkerAccessGrant>,
+    ) : AskCollateral
 
-    /*
-        SINGLE TRANSACTION TRADE:
-
-        {
-          "id" : "cbc40ee9-e79b-4763-be47-c2a442be8a3c",
-          "ask_type" : "marker_share_sale",
-          "owner" : "tp1yc4qpessmkxzc287te08kdku9gvta27fgr8m8y",
-          "collateral" : {
-            "marker_share_sale" : {
-              "address" : "tp14hmzymp860j0ufhn37xltq2hwrnp440y9dmwyw",
-              "denom" : "dankcoin",
-              "remaining_shares" : "100",
-              "quote_per_share" : [ {
-                "denom" : "nhash",
-                "amount" : "50"
-              } ],
-              "removed_permissions" : [ {
-                "address" : "tp1yc4qpessmkxzc287te08kdku9gvta27fgr8m8y",
-                "permissions" : [ "admin", "deposit", "withdraw", "burn", "mint", "delete" ]
-              } ],
-              "sale_type" : {
-                "single_transaction" : {
-                  "share_count" : "75"
-                }
-              }
-            }
-          },
-          "descriptor" : {
-            "description" : "Example description",
-            "effective_time" : "1655691526779913000",
-            "attribute_requirement" : {
-              "attributes" : [ "attr.sc.pb", "other.pio" ],
-              "requirement_type" : "none"
-            }
-          }
-        }
-     */
-
-    /*
-        MULTIPLE TRANSACTION TRADE:
-
-        {
-          "id" : "982457c3-18bd-4d8b-b5cf-1e09e9aa3bd8",
-          "ask_type" : "marker_share_sale",
-          "owner" : "tp1yc4qpessmkxzc287te08kdku9gvta27fgr8m8y",
-          "collateral" : {
-            "marker_share_sale" : {
-              "address" : "tp1cvgk23rpp96300gmfxchfuq0y0arm6wtsh3v3a",
-              "denom" : "noucoin",
-              "remaining_shares" : "100",
-              "quote_per_share" : [ {
-                "denom" : "nhash",
-                "amount" : "1000"
-              } ],
-              "removed_permissions" : [ {
-                "address" : "tp1yc4qpessmkxzc287te08kdku9gvta27fgr8m8y",
-                "permissions" : [ "admin", "deposit", "withdraw", "burn", "mint", "delete" ]
-              } ],
-              "sale_type" : {
-                "multiple_transactions" : {
-                  "remove_sale_share_threshold" : "75"
-                }
-              }
-            }
-          },
-          "descriptor" : {
-            "description" : "Example description",
-            "effective_time" : "1655691957648311000",
-            "attribute_requirement" : {
-              "attributes" : [ "yolo.pb", "nou.pio" ],
-              "requirement_type" : "all"
-            }
-          }
-        }
-     */
     @JsonNaming(SnakeCaseStrategy::class)
-    data class MarkerShareSale(val markerShareSale: Body) : AskCollateral {
-        @JsonNaming(SnakeCaseStrategy::class)
-        data class Body(
-            val address: String,
-            val denom: String,
-            val remainingShares: String,
-            val quotePerShare: List<Coin>,
-            val removedPermissions: List<MarkerAccessGrant>,
-            val saleType: ShareSaleType,
-        )
-    }
+    @JsonTypeName("marker_share_sale")
+    data class MarkerShareSale(
+        val markerAddress: String,
+        val markerDenom: String,
+        val totalSharesInSale: String,
+        val remainingSharesInSale: String,
+        val quotePerShare: List<Coin>,
+        val removedPermissions: List<MarkerAccessGrant>,
+        val saleType: ShareSaleType,
+    ) : AskCollateral
 
-    /*
-        {
-          "id" : "ac0b4ec2-089d-45b0-b649-b2d43f1bcf5f",
-          "ask_type" : "scope_trade",
-          "owner" : "tp1yc4qpessmkxzc287te08kdku9gvta27fgr8m8y",
-          "collateral" : {
-            "scope_trade" : {
-              "scope_address" : "scope1qz9puy0kqex5xfawzunfqrw25htquqr5ns",
-              "quote" : [ {
-                "denom" : "nhash",
-                "amount" : "50000"
-              } ]
-            }
-          },
-          "descriptor" : {
-            "description" : "Example description",
-            "effective_time" : "1655692117958721000",
-            "attribute_requirement" : {
-              "attributes" : [ "abc.pb", "xyz.pio" ],
-              "requirement_type" : "any"
-            }
-          }
-        }
-     */
     @JsonNaming(SnakeCaseStrategy::class)
-    data class ScopeTrade(val scopeTrade: Body) : AskCollateral {
-        @JsonNaming(SnakeCaseStrategy::class)
-        data class Body(
-            val scopeAddress: String,
-            val quote: List<Coin>,
-        )
-    }
+    @JsonTypeName("scope_trade")
+    data class ScopeTrade(
+        val scopeAddress: String,
+        val quote: List<Coin>,
+    ) : AskCollateral
 }
 
 data class MarkerAccessGrant(

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/models/BidOrder.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/models/BidOrder.kt
@@ -2,6 +2,7 @@ package io.provenance.bilateral.models
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.fasterxml.jackson.annotation.JsonTypeName
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy
 import com.fasterxml.jackson.databind.annotation.JsonNaming
 import cosmos.base.v1beta1.CoinOuterClass.Coin
@@ -20,189 +21,48 @@ data class BidOrder(
 ) {
     @JsonIgnore
     fun <T> mapCollateral(
-        coinTrade: (coinTrade: CoinTrade.Body) -> T,
-        markerTrade: (markerTrade: MarkerTrade.Body) -> T,
-        markerShareSale: (markerShareSale: MarkerShareSale.Body) -> T,
-        scopeTrade: (ScopeTrade.Body) -> T,
-    ): T = when (this.collateral) {
-        is CoinTrade -> coinTrade(this.collateral.coinTrade)
-        is MarkerTrade -> markerTrade(this.collateral.markerTrade)
-        is MarkerShareSale -> markerShareSale(this.collateral.markerShareSale)
-        is ScopeTrade -> scopeTrade(this.collateral.scopeTrade)
+        coinTrade: (coinTrade: CoinTrade) -> T,
+        markerTrade: (markerTrade: MarkerTrade) -> T,
+        markerShareSale: (markerShareSale: MarkerShareSale) -> T,
+        scopeTrade: (ScopeTrade) -> T,
+    ): T = when (collateral) {
+        is CoinTrade -> coinTrade(collateral)
+        is MarkerTrade -> markerTrade(collateral)
+        is MarkerShareSale -> markerShareSale(collateral)
+        is ScopeTrade -> scopeTrade(collateral)
     }
 }
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION)
+@JsonTypeInfo(include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.NAME)
 sealed interface BidCollateral {
-    /*
-        {
-          "id" : "c52eeda2-3224-4615-b5f9-e26a4a2f60a6",
-          "bid_type" : "coin_trade",
-          "owner" : "tp16v358yutrq9y24yny34j88yx7t48n6dn5c77v9",
-          "collateral" : {
-            "coin_trade" : {
-              "base" : [ {
-                "denom" : "nhash",
-                "amount" : "50"
-              } ],
-              "quote" : [ {
-                "denom" : "nhash",
-                "amount" : "100"
-              } ]
-            }
-          },
-          "descriptor" : {
-            "description" : "Example description",
-            "effective_time" : "1655690324377129000",
-            "attribute_requirement" : {
-              "attributes" : [ "heyo.pb" ],
-              "requirement_type" : "none"
-            }
-          }
-        }
-     */
     @JsonNaming(SnakeCaseStrategy::class)
-    data class CoinTrade(val coinTrade: Body) : BidCollateral {
-        @JsonNaming(SnakeCaseStrategy::class)
-        data class Body(
-            val base: List<Coin>,
-            val quote: List<Coin>,
-        )
-    }
+    @JsonTypeName("coin_trade")
+    data class CoinTrade(
+        val base: List<Coin>,
+        val quote: List<Coin>,
+    ) : BidCollateral
 
-    /*
-        {
-          "id" : "d186dd8d-5068-4b62-a118-d33fcb2cd544",
-          "bid_type" : "marker_trade",
-          "owner" : "tp16v358yutrq9y24yny34j88yx7t48n6dn5c77v9",
-          "collateral" : {
-            "marker_trade" : {
-              "address" : "tp1p3sl9tll0ygj3flwt5r2w0n6fx9p5ngqswjn5k",
-              "denom" : "testcoin",
-              "quote" : [ {
-                "denom" : "nhash",
-                "amount" : "500"
-              } ]
-            }
-          },
-          "descriptor" : {
-            "description" : "Example description",
-            "effective_time" : "1655690835272007000",
-            "attribute_requirement" : {
-              "attributes" : [ "whooaaaaahhhh.attr", "other.pio" ],
-              "requirement_type" : "all"
-            }
-          }
-        }
-     */
     @JsonNaming(SnakeCaseStrategy::class)
-    data class MarkerTrade(val markerTrade: Body) : BidCollateral {
-        @JsonNaming(SnakeCaseStrategy::class)
-        data class Body(
-            val address: String,
-            val denom: String,
-            val quote: List<Coin>,
-        )
-    }
+    @JsonTypeName("marker_trade")
+    data class MarkerTrade(
+        val markerAddress: String,
+        val markerDenom: String,
+        val quote: List<Coin>,
+    ) : BidCollateral
 
-    /*
-        SINGLE TRANSACTION TRADE:
-
-        {
-          "id" : "ee44d587-fd11-4803-b372-a820c41c4dfa",
-          "bid_type" : "marker_share_sale",
-          "owner" : "tp16v358yutrq9y24yny34j88yx7t48n6dn5c77v9",
-          "collateral" : {
-            "marker_share_sale" : {
-              "address" : "tp14hmzymp860j0ufhn37xltq2hwrnp440y9dmwyw",
-              "denom" : "dankcoin",
-              "share_count" : "75",
-              "quote" : [ {
-                "denom" : "nhash",
-                "amount" : "3750"
-              } ]
-            }
-          },
-          "descriptor" : {
-            "description" : "Example description",
-            "effective_time" : "1655691531898653000",
-            "attribute_requirement" : {
-              "attributes" : [ "hey.pb", "lol.pio" ],
-              "requirement_type" : "any"
-            }
-          }
-        }
-     */
-
-    /*
-        MULTIPLE TRANSACTION TRADE:
-
-        {
-          "id" : "943b7f98-ffcd-4174-99a4-fda94f6a8f7c",
-          "bid_type" : "marker_share_sale",
-          "owner" : "tp16v358yutrq9y24yny34j88yx7t48n6dn5c77v9",
-          "collateral" : {
-            "marker_share_sale" : {
-              "address" : "tp1cvgk23rpp96300gmfxchfuq0y0arm6wtsh3v3a",
-              "denom" : "noucoin",
-              "share_count" : "25",
-              "quote" : [ {
-                "denom" : "nhash",
-                "amount" : "25000"
-              } ]
-            }
-          },
-          "descriptor" : {
-            "description" : "Example description",
-            "effective_time" : "1655691962780823000",
-            "attribute_requirement" : {
-              "attributes" : [ "aaaaaaahhhhh.pb", "helpme.pio" ],
-              "requirement_type" : "none"
-            }
-          }
-        }
-     */
     @JsonNaming(SnakeCaseStrategy::class)
-    data class MarkerShareSale(val markerShareSale: Body) : BidCollateral {
-        @JsonNaming(SnakeCaseStrategy::class)
-        data class Body(
-            val address: String,
-            val denom: String,
-            val shareCount: String,
-            val quote: List<Coin>,
-        )
-    }
+    @JsonTypeName("marker_share_sale")
+    data class MarkerShareSale(
+        val markerAddress: String,
+        val markerDenom: String,
+        val shareCount: String,
+        val quote: List<Coin>,
+    ) : BidCollateral
 
-    /*
-        {
-          "id" : "721305c5-4a82-4174-81ed-225342f9e377",
-          "bid_type" : "scope_trade",
-          "owner" : "tp1yc4qpessmkxzc287te08kdku9gvta27fgr8m8y",
-          "collateral" : {
-            "scope_trade" : {
-              "scope_address" : "scope1qz9puy0kqex5xfawzunfqrw25htquqr5ns",
-              "quote" : [ {
-                "denom" : "nhash",
-                "amount" : "50000"
-              } ]
-            }
-          },
-          "descriptor" : {
-            "description" : "Example description",
-            "effective_time" : "1655692123071177000",
-            "attribute_requirement" : {
-              "attributes" : [ "www.billywitchdoctor.com.pb", "jlksdfljksdfljk.pio" ],
-              "requirement_type" : "all"
-            }
-          }
-        }
-     */
     @JsonNaming(SnakeCaseStrategy::class)
-    data class ScopeTrade(val scopeTrade: Body) : BidCollateral {
-        @JsonNaming(SnakeCaseStrategy::class)
-        data class Body(
-            val scopeAddress: String,
-            val quote: List<Coin>,
-        )
-    }
+    @JsonTypeName("scope_trade")
+    data class ScopeTrade(
+        val scopeAddress: String,
+        val quote: List<Coin>,
+    ) : BidCollateral
 }

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/models/ShareSaleType.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/models/ShareSaleType.kt
@@ -1,30 +1,13 @@
 package io.provenance.bilateral.models
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo
-import com.fasterxml.jackson.databind.PropertyNamingStrategies
-import com.fasterxml.jackson.databind.annotation.JsonNaming
+import com.fasterxml.jackson.annotation.JsonProperty
 
 /**
  * See CreateAsk for a JSON payload that includes this object's use.
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION)
-sealed interface ShareSaleType {
-    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
-    data class SingleTransaction(val singleTransaction: Body) : ShareSaleType {
-        @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
-        data class Body(val shareCount: String)
-    }
-
-    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
-    data class MultipleTransactions(val multipleTransactions: Body) : ShareSaleType {
-        @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
-        data class Body(val removeSaleShareThreshold: String?)
-    }
-
-    companion object {
-        fun single(shareCount: String): ShareSaleType = SingleTransaction(SingleTransaction.Body(shareCount))
-
-        fun multiple(removeSaleShareThreshold: String? = null): ShareSaleType =
-            MultipleTransactions(MultipleTransactions.Body(removeSaleShareThreshold))
-    }
+enum class ShareSaleType {
+    @JsonProperty("single_transaction")
+    SINGLE_TRANSACTION,
+    @JsonProperty("multiple_transactions")
+    MULTIPLE_TRANSACTIONS,
 }

--- a/smart-contract/Cargo.lock
+++ b/smart-contract/Cargo.lock
@@ -338,7 +338,7 @@ checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "metadata-bilateral-exchange"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/smart-contract/Cargo.toml
+++ b/smart-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metadata-bilateral-exchange"
-version = "1.0.2"
+version = "1.0.3"
 authors = ["Jake Schwartz <jschwartz@figure.com>", "Ken Talley <ktalley@figure.com>"]
 edition = "2018"
 

--- a/smart-contract/schema/ask_order.json
+++ b/smart-contract/schema/ask_order.json
@@ -187,18 +187,19 @@
     "MarkerShareSaleAskCollateral": {
       "type": "object",
       "required": [
-        "address",
-        "denom",
+        "marker_address",
+        "marker_denom",
         "quote_per_share",
-        "remaining_shares",
+        "remaining_shares_in_sale",
         "removed_permissions",
-        "sale_type"
+        "sale_type",
+        "total_shares_in_sale"
       ],
       "properties": {
-        "address": {
+        "marker_address": {
           "$ref": "#/definitions/Addr"
         },
-        "denom": {
+        "marker_denom": {
           "type": "string"
         },
         "quote_per_share": {
@@ -207,7 +208,7 @@
             "$ref": "#/definitions/Coin"
           }
         },
-        "remaining_shares": {
+        "remaining_shares_in_sale": {
           "$ref": "#/definitions/Uint128"
         },
         "removed_permissions": {
@@ -218,23 +219,26 @@
         },
         "sale_type": {
           "$ref": "#/definitions/ShareSaleType"
+        },
+        "total_shares_in_sale": {
+          "$ref": "#/definitions/Uint128"
         }
       }
     },
     "MarkerTradeAskCollateral": {
       "type": "object",
       "required": [
-        "address",
-        "denom",
+        "marker_address",
+        "marker_denom",
         "quote_per_share",
         "removed_permissions",
         "share_count"
       ],
       "properties": {
-        "address": {
+        "marker_address": {
           "$ref": "#/definitions/Addr"
         },
-        "denom": {
+        "marker_denom": {
           "type": "string"
         },
         "quote_per_share": {
@@ -313,53 +317,10 @@
       }
     },
     "ShareSaleType": {
-      "anyOf": [
-        {
-          "description": "Indicates that only a single transaction will be made after an ask of this share type is made. Ex: Asker indicates they want to sell  80 shares of their marker at a certain quote.  The bidder must buy exactly that many shares.",
-          "type": "object",
-          "required": [
-            "single_transaction"
-          ],
-          "properties": {
-            "single_transaction": {
-              "type": "object",
-              "required": [
-                "share_count"
-              ],
-              "properties": {
-                "share_count": {
-                  "$ref": "#/definitions/Uint128"
-                }
-              }
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "description": "Indicates that multiple transactions can be made after an ask of this share type is made. Optionally allows the sale to be withdrawn after a certain share count is met.  This ensures that shares can be purchased many times from the marker, but never more shares than would reduce the marker's share count below the specified threshold.  The ask is automatically deleted after the threshold is hit.  If the value is not specified, a default of zero will be used. Ex: Asker indicates they want to sell shares of their marker until there are only 10 remaining.  Multiple bids can come in and incrementally buy shares from the marker.  Once the threshold of 10 remaining shares is hit, the ask will be automatically deleted.",
-          "type": "object",
-          "required": [
-            "multiple_transactions"
-          ],
-          "properties": {
-            "multiple_transactions": {
-              "type": "object",
-              "properties": {
-                "remove_sale_share_threshold": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/Uint128"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          "additionalProperties": false
-        }
+      "type": "string",
+      "enum": [
+        "single_transaction",
+        "multiple_transactions"
       ]
     },
     "Timestamp": {

--- a/smart-contract/schema/bid_order.json
+++ b/smart-contract/schema/bid_order.json
@@ -154,16 +154,16 @@
     "MarkerShareSaleBidCollateral": {
       "type": "object",
       "required": [
-        "address",
-        "denom",
+        "marker_address",
+        "marker_denom",
         "quote",
         "share_count"
       ],
       "properties": {
-        "address": {
+        "marker_address": {
           "$ref": "#/definitions/Addr"
         },
-        "denom": {
+        "marker_denom": {
           "type": "string"
         },
         "quote": {
@@ -180,15 +180,15 @@
     "MarkerTradeBidCollateral": {
       "type": "object",
       "required": [
-        "address",
-        "denom",
+        "marker_address",
+        "marker_denom",
         "quote"
       ],
       "properties": {
-        "address": {
+        "marker_address": {
           "$ref": "#/definitions/Addr"
         },
-        "denom": {
+        "marker_denom": {
           "type": "string"
         },
         "quote": {

--- a/smart-contract/schema/execute_msg.json
+++ b/smart-contract/schema/execute_msg.json
@@ -338,16 +338,17 @@
     "MarkerShareSaleAsk": {
       "type": "object",
       "required": [
-        "denom",
         "id",
+        "marker_denom",
         "quote_per_share",
-        "share_sale_type"
+        "share_sale_type",
+        "shares_to_sell"
       ],
       "properties": {
-        "denom": {
+        "id": {
           "type": "string"
         },
-        "id": {
+        "marker_denom": {
           "type": "string"
         },
         "quote_per_share": {
@@ -358,21 +359,24 @@
         },
         "share_sale_type": {
           "$ref": "#/definitions/ShareSaleType"
+        },
+        "shares_to_sell": {
+          "$ref": "#/definitions/Uint128"
         }
       }
     },
     "MarkerShareSaleBid": {
       "type": "object",
       "required": [
-        "denom",
         "id",
+        "marker_denom",
         "share_count"
       ],
       "properties": {
-        "denom": {
+        "id": {
           "type": "string"
         },
-        "id": {
+        "marker_denom": {
           "type": "string"
         },
         "share_count": {
@@ -383,15 +387,15 @@
     "MarkerTradeAsk": {
       "type": "object",
       "required": [
-        "denom",
         "id",
+        "marker_denom",
         "quote_per_share"
       ],
       "properties": {
-        "denom": {
+        "id": {
           "type": "string"
         },
-        "id": {
+        "marker_denom": {
           "type": "string"
         },
         "quote_per_share": {
@@ -405,14 +409,14 @@
     "MarkerTradeBid": {
       "type": "object",
       "required": [
-        "denom",
-        "id"
+        "id",
+        "marker_denom"
       ],
       "properties": {
-        "denom": {
+        "id": {
           "type": "string"
         },
-        "id": {
+        "marker_denom": {
           "type": "string"
         }
       }
@@ -515,53 +519,10 @@
       }
     },
     "ShareSaleType": {
-      "anyOf": [
-        {
-          "description": "Indicates that only a single transaction will be made after an ask of this share type is made. Ex: Asker indicates they want to sell  80 shares of their marker at a certain quote.  The bidder must buy exactly that many shares.",
-          "type": "object",
-          "required": [
-            "single_transaction"
-          ],
-          "properties": {
-            "single_transaction": {
-              "type": "object",
-              "required": [
-                "share_count"
-              ],
-              "properties": {
-                "share_count": {
-                  "$ref": "#/definitions/Uint128"
-                }
-              }
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "description": "Indicates that multiple transactions can be made after an ask of this share type is made. Optionally allows the sale to be withdrawn after a certain share count is met.  This ensures that shares can be purchased many times from the marker, but never more shares than would reduce the marker's share count below the specified threshold.  The ask is automatically deleted after the threshold is hit.  If the value is not specified, a default of zero will be used. Ex: Asker indicates they want to sell shares of their marker until there are only 10 remaining.  Multiple bids can come in and incrementally buy shares from the marker.  Once the threshold of 10 remaining shares is hit, the ask will be automatically deleted.",
-          "type": "object",
-          "required": [
-            "multiple_transactions"
-          ],
-          "properties": {
-            "multiple_transactions": {
-              "type": "object",
-              "properties": {
-                "remove_sale_share_threshold": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/Uint128"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          "additionalProperties": false
-        }
+      "type": "string",
+      "enum": [
+        "single_transaction",
+        "multiple_transactions"
       ]
     },
     "Timestamp": {

--- a/smart-contract/schema/migrate_msg.json
+++ b/smart-contract/schema/migrate_msg.json
@@ -13,6 +13,18 @@
         }
       },
       "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "migrate_legacy_orders"
+      ],
+      "properties": {
+        "migrate_legacy_orders": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
     }
   ]
 }

--- a/smart-contract/src/contract.rs
+++ b/smart-contract/src/contract.rs
@@ -6,6 +6,7 @@ use crate::execute::execute_match::execute_match;
 use crate::execute::update_settings::update_settings;
 use crate::instantiate::instantiate_contract::instantiate_contract;
 use crate::migrate::migrate_contract::migrate_contract;
+use crate::migrate::migrate_legacy_orders::migrate_legacy_orders;
 use crate::query::get_ask::query_ask;
 use crate::query::get_ask_by_collateral_id::query_ask_by_collateral_id;
 use crate::query::get_bid::query_bid;
@@ -78,6 +79,7 @@ pub fn migrate(
     msg: MigrateMsg,
 ) -> Result<Response<ProvenanceMsg>, ContractError> {
     match msg {
-        MigrateMsg::ContractUpgrade {} => migrate_contract(deps),
+        MigrateMsg::ContractUpgrade {} => migrate_contract(&deps),
+        MigrateMsg::MigrateLegacyOrders {} => migrate_legacy_orders(deps),
     }
 }

--- a/smart-contract/src/execute/cancel_ask.rs
+++ b/smart-contract/src/execute/cancel_ask.rs
@@ -42,14 +42,14 @@ pub fn cancel_ask(
         }
         AskCollateral::MarkerTrade(collateral) => {
             messages.append(&mut release_marker_from_contract(
-                &collateral.denom,
+                &collateral.marker_denom,
                 &env.contract.address,
                 &collateral.removed_permissions,
             )?);
         }
         AskCollateral::MarkerShareSale(collateral) => {
             messages.append(&mut release_marker_from_contract(
-                &collateral.denom,
+                &collateral.marker_denom,
                 &env.contract.address,
                 &collateral.removed_permissions,
             )?);
@@ -312,8 +312,9 @@ mod tests {
             Ask::new_marker_share_sale(
                 &ask_id,
                 DEFAULT_MARKER_DENOM,
+                DEFAULT_MARKER_HOLDINGS,
                 &coins(150, "nhash"),
-                ShareSaleType::single(DEFAULT_MARKER_HOLDINGS),
+                ShareSaleType::SingleTransaction,
             ),
             None,
         )

--- a/smart-contract/src/execute/create_bid.rs
+++ b/smart-contract/src/execute/create_bid.rs
@@ -95,7 +95,8 @@ fn create_marker_trade_collateral(
         .to_err();
     }
     // This grants us access to the marker address, as well as ensuring that the marker is real
-    let marker = ProvenanceQuerier::new(&deps.querier).get_marker_by_denom(&marker_trade.marker_denom)?;
+    let marker =
+        ProvenanceQuerier::new(&deps.querier).get_marker_by_denom(&marker_trade.marker_denom)?;
     BidCollateral::marker_trade(marker.address, &marker_trade.marker_denom, quote_funds).to_ok()
 }
 
@@ -122,8 +123,8 @@ fn create_marker_share_sale_collateral(
         )
         .to_err();
     }
-    let marker =
-        ProvenanceQuerier::new(&deps.querier).get_marker_by_denom(&marker_share_sale.marker_denom)?;
+    let marker = ProvenanceQuerier::new(&deps.querier)
+        .get_marker_by_denom(&marker_share_sale.marker_denom)?;
     let marker_shares_available = get_single_marker_coin_holding(&marker)?.amount.u128();
     if marker_share_sale.share_count.u128() > marker_shares_available {
         return ContractError::validation_error(&[format!(

--- a/smart-contract/src/execute/create_bid.rs
+++ b/smart-contract/src/execute/create_bid.rs
@@ -85,7 +85,7 @@ fn create_marker_trade_collateral(
     if marker_trade.id.is_empty() {
         return ContractError::missing_field("id").to_err();
     }
-    if marker_trade.denom.is_empty() {
+    if marker_trade.marker_denom.is_empty() {
         return ContractError::missing_field("denom").to_err();
     }
     if quote_funds.is_empty() {
@@ -95,8 +95,8 @@ fn create_marker_trade_collateral(
         .to_err();
     }
     // This grants us access to the marker address, as well as ensuring that the marker is real
-    let marker = ProvenanceQuerier::new(&deps.querier).get_marker_by_denom(&marker_trade.denom)?;
-    BidCollateral::marker_trade(marker.address, &marker_trade.denom, quote_funds).to_ok()
+    let marker = ProvenanceQuerier::new(&deps.querier).get_marker_by_denom(&marker_trade.marker_denom)?;
+    BidCollateral::marker_trade(marker.address, &marker_trade.marker_denom, quote_funds).to_ok()
 }
 
 fn create_marker_share_sale_collateral(
@@ -107,7 +107,7 @@ fn create_marker_share_sale_collateral(
     if marker_share_sale.id.is_empty() {
         return ContractError::missing_field("id").to_err();
     }
-    if marker_share_sale.denom.is_empty() {
+    if marker_share_sale.marker_denom.is_empty() {
         return ContractError::missing_field("denom").to_err();
     }
     if marker_share_sale.share_count.is_zero() {
@@ -123,20 +123,20 @@ fn create_marker_share_sale_collateral(
         .to_err();
     }
     let marker =
-        ProvenanceQuerier::new(&deps.querier).get_marker_by_denom(&marker_share_sale.denom)?;
+        ProvenanceQuerier::new(&deps.querier).get_marker_by_denom(&marker_share_sale.marker_denom)?;
     let marker_shares_available = get_single_marker_coin_holding(&marker)?.amount.u128();
     if marker_share_sale.share_count.u128() > marker_shares_available {
         return ContractError::validation_error(&[format!(
             "share count [{}] must be less than or equal to remaining [{}] shares available [{}]",
             marker_share_sale.share_count.u128(),
-            marker_share_sale.denom,
+            marker_share_sale.marker_denom,
             marker_shares_available,
         )])
         .to_err();
     }
     BidCollateral::marker_share_sale(
         marker.address,
-        &marker_share_sale.denom,
+        &marker_share_sale.marker_denom,
         marker_share_sale.share_count.u128(),
         quote_funds,
     )
@@ -907,11 +907,11 @@ mod tests {
         );
         let collateral = bid_order.collateral.unwrap_marker_trade();
         assert_eq!(
-            DEFAULT_MARKER_ADDRESS, collateral.address,
+            DEFAULT_MARKER_ADDRESS, collateral.marker_address,
             "the correct marker address should be set on the collateral",
         );
         assert_eq!(
-            DEFAULT_MARKER_DENOM, collateral.denom,
+            DEFAULT_MARKER_DENOM, collateral.marker_denom,
             "the correct marker denom should be set on the collateral",
         );
         assert_eq!(
@@ -962,11 +962,11 @@ mod tests {
         let collateral = bid_order.collateral.unwrap_marker_share_sale();
         assert_eq!(
             DEFAULT_MARKER_ADDRESS,
-            collateral.address.as_str(),
+            collateral.marker_address.as_str(),
             "the correct marker address should be set in the collateral",
         );
         assert_eq!(
-            DEFAULT_MARKER_DENOM, collateral.denom,
+            DEFAULT_MARKER_DENOM, collateral.marker_denom,
             "the correct marker denom should be set in the collateral",
         );
         assert_eq!(

--- a/smart-contract/src/migrate/migrate_contract.rs
+++ b/smart-contract/src/migrate/migrate_contract.rs
@@ -6,7 +6,7 @@ use provwasm_std::{ProvenanceMsg, ProvenanceQuery};
 use semver::Version;
 
 pub fn migrate_contract(
-    deps: DepsMut<ProvenanceQuery>,
+    deps: &DepsMut<ProvenanceQuery>,
 ) -> Result<Response<ProvenanceMsg>, ContractError> {
     let mut contract_info = get_contract_info(deps.storage)?;
     check_valid_migration_versioning(&contract_info)?;
@@ -45,7 +45,7 @@ mod tests {
         let mut deps = mock_dependencies(&[]);
         default_instantiate(deps.as_mut().storage);
         let response =
-            migrate_contract(deps.as_mut()).expect("expected a simple migrate to succeed");
+            migrate_contract(&deps.as_mut()).expect("expected a simple migrate to succeed");
         assert!(
             response.messages.is_empty(),
             "migrations should never produce messages",
@@ -76,7 +76,7 @@ mod tests {
         contract_info.contract_version = "999.999.999".to_string();
         set_contract_info(deps.as_mut().storage, &contract_info)
             .expect("expected contract info to be stored successfully");
-        let err = migrate_contract(deps.as_mut())
+        let err = migrate_contract(&deps.as_mut())
             .expect_err("an error should be produced if the contract is downgraded");
         match err {
             ContractError::InvalidMigration { message } => {

--- a/smart-contract/src/migrate/migrate_legacy_orders.rs
+++ b/smart-contract/src/migrate/migrate_legacy_orders.rs
@@ -1,0 +1,309 @@
+use crate::migrate::migrate_contract::migrate_contract;
+use crate::storage::ask_order_storage::insert_ask_order;
+use crate::storage::bid_order_storage::insert_bid_order;
+use crate::storage::legacy_ask_order_storage::{
+    get_converted_legacy_ask_orders, legacy_ask_orders,
+};
+use crate::storage::legacy_bid_order_storage::{
+    get_converted_legacy_bid_orders, legacy_bid_orders,
+};
+use crate::types::core::error::ContractError;
+use crate::util::extensions::ResultExtensions;
+use cosmwasm_std::{DepsMut, Response};
+use provwasm_std::{ProvenanceMsg, ProvenanceQuery};
+
+pub fn migrate_legacy_orders(
+    deps: DepsMut<ProvenanceQuery>,
+) -> Result<Response<ProvenanceMsg>, ContractError> {
+    let migration_response = migrate_contract(&deps)?;
+    let converted_ask_orders = get_converted_legacy_ask_orders(deps.storage)?;
+    for ask_order in &converted_ask_orders {
+        // Remove ask order using the legacy storage, avoiding any schema mismatches between old and new
+        legacy_ask_orders().remove(deps.storage, ask_order.id.as_bytes())?;
+        // Insert the converted order using the new storage, ensuring new schema is adopted
+        insert_ask_order(deps.storage, ask_order)?;
+    }
+    let converted_bid_orders = get_converted_legacy_bid_orders(deps.storage)?;
+    for bid_order in &converted_bid_orders {
+        // Remove ask order using the legacy storage, avoiding any schema mismatches between old and new
+        legacy_bid_orders().remove(deps.storage, bid_order.id.as_bytes())?;
+        // Insert the converted order using the new storage, ensuring new schema is adopted
+        insert_bid_order(deps.storage, bid_order)?;
+    }
+    migration_response
+        .add_attribute(
+            "converted_ask_orders",
+            converted_ask_orders.len().to_string(),
+        )
+        .add_attribute(
+            "converted_bid_orders",
+            converted_bid_orders.len().to_string(),
+        )
+        .to_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::migrate::migrate_legacy_orders::migrate_legacy_orders;
+    use crate::storage::ask_order_storage::get_ask_order_by_id;
+    use crate::storage::bid_order_storage::get_bid_order_by_id;
+    use crate::storage::contract_info::CONTRACT_VERSION;
+    use crate::storage::legacy_ask_order_storage::legacy_ask_orders;
+    use crate::storage::legacy_bid_order_storage::legacy_bid_orders;
+    use crate::test::cosmos_type_helpers::single_attribute_for_key;
+    use crate::test::mock_instantiate::default_instantiate;
+    use crate::types::request::ask_types::legacy_ask_collateral::LegacyAskCollateral;
+    use crate::types::request::ask_types::legacy_ask_order::LegacyAskOrder;
+    use crate::types::request::bid_types::legacy_bid_collateral::LegacyBidCollateral;
+    use crate::types::request::bid_types::legacy_bid_order::LegacyBidOrder;
+    use crate::types::request::legacy_share_sale_type::LegacyShareSaleType;
+    use crate::types::request::request_descriptor::{AttributeRequirement, RequestDescriptor};
+    use crate::types::request::request_type::RequestType;
+    use cosmwasm_std::{coins, Addr, Storage, Uint128};
+    use provwasm_mocks::mock_dependencies;
+
+    #[test]
+    fn test_successful_simple_batch_conversion() {
+        let mut deps = mock_dependencies(&[]);
+        default_instantiate(deps.as_mut().storage);
+        let legacy_ask = LegacyAskOrder {
+            id: "ask_id".to_string(),
+            ask_type: RequestType::MarkerTrade,
+            owner: Addr::unchecked("asker"),
+            collateral: LegacyAskCollateral::marker_trade(
+                Addr::unchecked("marker address"),
+                "marker denom",
+                100,
+                &coins(100, "quote"),
+                &[],
+            ),
+            descriptor: Some(RequestDescriptor::new_populated_attributes(
+                "description",
+                AttributeRequirement::all(&["something.pb"]),
+            )),
+        };
+        insert_legacy_ask_order(deps.as_mut().storage, &legacy_ask);
+        let legacy_bid = LegacyBidOrder {
+            id: "bid_id".to_string(),
+            bid_type: RequestType::MarkerTrade,
+            owner: Addr::unchecked("bidder"),
+            collateral: LegacyBidCollateral::marker_trade(
+                Addr::unchecked("marker address"),
+                "marker denom",
+                &coins(100, "quote"),
+            ),
+            descriptor: Some(RequestDescriptor::new_populated_attributes(
+                "description",
+                AttributeRequirement::none(&["NONE.PIO"]),
+            )),
+        };
+        insert_legacy_bid_order(deps.as_mut().storage, &legacy_bid);
+        get_ask_order_by_id(deps.as_ref().storage, &legacy_ask.id)
+            .expect_err("trying to load the legacy ask order before conversion should fail");
+        get_bid_order_by_id(deps.as_ref().storage, &legacy_bid.id)
+            .expect_err("trying to load the legacy bid order before conversion should fail");
+        let response =
+            migrate_legacy_orders(deps.as_mut()).expect("expected the migration to succeed");
+        assert!(
+            response.messages.is_empty(),
+            "migrations should never emit messages",
+        );
+        assert_eq!(
+            4,
+            response.attributes.len(),
+            "all proper attributes should be emitted by the migration",
+        );
+        assert_eq!(
+            "migrate_contract",
+            single_attribute_for_key(&response, "action"),
+            "the action attribute should have the correct value",
+        );
+        assert_eq!(
+            CONTRACT_VERSION,
+            single_attribute_for_key(&response, "new_version"),
+            "the new_version attribute should have the correct value",
+        );
+        assert_eq!(
+            "1",
+            single_attribute_for_key(&response, "converted_ask_orders"),
+            "the converted_ask_orders attribute should show that a single ask order was converted",
+        );
+        assert_eq!(
+            "1",
+            single_attribute_for_key(&response, "converted_bid_orders"),
+            "the converted_bid_orders attribute should show that a single bid order was converted",
+        );
+        let new_ask_order = get_ask_order_by_id(deps.as_mut().storage, &legacy_ask.id)
+            .expect("the new ask order should load from storage");
+        assert_eq!(
+            legacy_ask.to_new_ask_order(),
+            new_ask_order,
+            "the new ask order should be converted from the old value",
+        );
+        let new_bid_order = get_bid_order_by_id(deps.as_mut().storage, &legacy_bid.id)
+            .expect("the new bid order should load from storage");
+        assert_eq!(
+            legacy_bid.to_new_bid_order(),
+            new_bid_order,
+            "the new bid order should be converted from the old value",
+        );
+    }
+
+    #[test]
+    fn test_large_batch_conversion() {
+        let mut deps = mock_dependencies(&[]);
+        default_instantiate(deps.as_mut().storage);
+        let mut legacy_ask_orders = vec![];
+        for ask_id in 0..100 {
+            let legacy_ask = LegacyAskOrder {
+                id: format!("ask_id_{}", ask_id),
+                ask_type: RequestType::MarkerShareSale,
+                owner: Addr::unchecked(format!("asker_{}", ask_id)),
+                collateral: LegacyAskCollateral::marker_share_sale(
+                    Addr::unchecked(format!("marker_{}", ask_id)),
+                    format!("denom_{}", ask_id),
+                    100,
+                    &coins(100, "quote"),
+                    &[],
+                    if ask_id % 2 == 0 {
+                        LegacyShareSaleType::SingleTransaction {
+                            share_count: Uint128::new(50),
+                        }
+                    } else {
+                        LegacyShareSaleType::MultipleTransactions {
+                            remove_sale_share_threshold: Some(Uint128::new(10)),
+                        }
+                    },
+                ),
+                descriptor: Some(RequestDescriptor::new_populated_attributes(
+                    "description",
+                    AttributeRequirement::all(&["something.pb"]),
+                )),
+            };
+            insert_legacy_ask_order(deps.as_mut().storage, &legacy_ask);
+            legacy_ask_orders.push(legacy_ask);
+        }
+        let mut legacy_bid_orders = vec![];
+        for bid_id in 0..100 {
+            let legacy_bid = LegacyBidOrder {
+                id: format!("bid_id_{}", bid_id),
+                bid_type: RequestType::MarkerShareSale,
+                owner: Addr::unchecked(format!("bidder_{}", bid_id)),
+                collateral: LegacyBidCollateral::marker_share_sale(
+                    Addr::unchecked(format!("marker_{}", bid_id)),
+                    format!("denom_{}", bid_id),
+                    100,
+                    &coins(100, "quote"),
+                ),
+                descriptor: Some(RequestDescriptor::new_populated_attributes(
+                    "description",
+                    AttributeRequirement::none(&["NONE.PIO"]),
+                )),
+            };
+            insert_legacy_bid_order(deps.as_mut().storage, &legacy_bid);
+            legacy_bid_orders.push(legacy_bid);
+        }
+        let response = migrate_legacy_orders(deps.as_mut()).expect("migration should succeed");
+        assert!(
+            response.messages.is_empty(),
+            "migrations should never emit messages",
+        );
+        assert_eq!(
+            4,
+            response.attributes.len(),
+            "all proper attributes should be emitted by the migration",
+        );
+        assert_eq!(
+            "migrate_contract",
+            single_attribute_for_key(&response, "action"),
+            "the action attribute should have the correct value",
+        );
+        assert_eq!(
+            CONTRACT_VERSION,
+            single_attribute_for_key(&response, "new_version"),
+            "the new_version attribute should have the correct value",
+        );
+        assert_eq!(
+            "100",
+            single_attribute_for_key(&response, "converted_ask_orders"),
+            "the converted_ask_orders attribute should show that all ask orders were converted",
+        );
+        assert_eq!(
+            "100",
+            single_attribute_for_key(&response, "converted_bid_orders"),
+            "the converted_bid_orders attribute should show that all bid orders were converted",
+        );
+        for legacy_ask in legacy_ask_orders {
+            let new_ask_order = get_ask_order_by_id(deps.as_mut().storage, &legacy_ask.id)
+                .unwrap_or_else(|e| {
+                    panic!(
+                        "the new ask order with id [{}] should load from storage, got error: {:?}",
+                        legacy_ask.id, e,
+                    )
+                });
+            assert_eq!(
+                legacy_ask.to_new_ask_order(),
+                new_ask_order,
+                "the new ask order with id [{}] should be converted from the old value",
+                new_ask_order.id,
+            );
+        }
+        for legacy_bid in legacy_bid_orders {
+            let new_bid_order = get_bid_order_by_id(deps.as_mut().storage, &legacy_bid.id)
+                .unwrap_or_else(|e| {
+                    panic!(
+                        "the new bid order with id [{}] should load from storage, got error: {:?}",
+                        legacy_bid.id, e
+                    )
+                });
+            assert_eq!(
+                legacy_bid.to_new_bid_order(),
+                new_bid_order,
+                "the new bid order with id [{}] should be converted from the old value",
+                new_bid_order.id,
+            );
+        }
+    }
+
+    fn insert_legacy_ask_order(storage: &mut dyn Storage, ask_order: &LegacyAskOrder) {
+        let state = legacy_ask_orders();
+        if let Ok(existing_ask) = state.load(storage, ask_order.get_pk()) {
+            panic!(
+                "an ask with id [{}] for owner [{}] already exists",
+                existing_ask.id,
+                existing_ask.owner.as_str(),
+            );
+        }
+        legacy_ask_orders()
+            .replace(storage, ask_order.get_pk(), Some(ask_order), None)
+            .expect("legacy ask order insert should succeed");
+        let inserted_ask_order = state
+            .load(storage, ask_order.id.as_bytes())
+            .expect("expected legacy ask order to be available in storage");
+        assert_eq!(
+            &inserted_ask_order, ask_order,
+            "expected the inserted value to equate to the value fetched",
+        );
+    }
+
+    fn insert_legacy_bid_order(storage: &mut dyn Storage, bid_order: &LegacyBidOrder) {
+        let state = legacy_bid_orders();
+        if let Ok(existing_bid) = state.load(storage, bid_order.get_pk()) {
+            panic!(
+                "a bid with id [{}] for owner [{}] already exists",
+                existing_bid.id,
+                existing_bid.owner.as_str()
+            );
+        }
+        legacy_bid_orders()
+            .replace(storage, bid_order.get_pk(), Some(bid_order), None)
+            .expect("legacy bid order insert should succeed");
+        let inserted_bid_order = state
+            .load(storage, bid_order.id.as_bytes())
+            .expect("expected legacy bid order to be available in storage");
+        assert_eq!(
+            &inserted_bid_order, bid_order,
+            "expected the inserted value to equate to the value fetched",
+        );
+    }
+}

--- a/smart-contract/src/migrate/mod.rs
+++ b/smart-contract/src/migrate/mod.rs
@@ -1,1 +1,2 @@
 pub mod migrate_contract;
+pub mod migrate_legacy_orders;

--- a/smart-contract/src/query/get_match_report.rs
+++ b/smart-contract/src/query/get_match_report.rs
@@ -1,253 +1,257 @@
-use crate::storage::ask_order_storage::get_ask_order_by_id;
-use crate::storage::bid_order_storage::get_bid_order_by_id;
 use crate::types::core::error::ContractError;
-use crate::types::request::match_report::MatchReport;
-use crate::validation::execute_match_validation::validate_match;
+use crate::util::extensions::ResultExtensions;
 use cosmwasm_std::{Binary, Deps};
 use provwasm_std::ProvenanceQuery;
 
 pub fn get_match_report(
-    deps: Deps<ProvenanceQuery>,
-    ask_id: String,
-    bid_id: String,
+    _deps: Deps<ProvenanceQuery>,
+    _ask_id: String,
+    _bid_id: String,
 ) -> Result<Binary, ContractError> {
-    let ask_order_result = get_ask_order_by_id(deps.storage, &ask_id);
-    let bid_order_result = get_bid_order_by_id(deps.storage, &bid_id);
-    if ask_order_result.is_err() || bid_order_result.is_err() {
-        return MatchReport::new_missing_order(
-            ask_id,
-            bid_id,
-            ask_order_result.is_ok(),
-            bid_order_result.is_ok(),
-        )?
-        .to_binary();
-    }
-    let ask_order = ask_order_result.unwrap();
-    let bid_order = bid_order_result.unwrap();
-    let standard_match_result = validate_match(&deps, &ask_order, &bid_order, false);
-    let quote_mismatch_result = validate_match(&deps, &ask_order, &bid_order, true);
-    let mut error_messages = vec![];
-    if let Err(e) = &standard_match_result {
-        error_messages.push(format!("Standard match fails due to: {:?}", e))
-    }
-    if let Err(e) = &quote_mismatch_result {
-        error_messages.push(format!(
-            "Quote mismatch-enabled match fails due to: {:?}",
-            e
-        ))
-    }
-    MatchReport::new_existing_orders(
-        ask_id,
-        bid_id,
-        standard_match_result.is_ok(),
-        quote_mismatch_result.is_ok(),
-        &error_messages,
-    )
-    .to_binary()
+    // The code required to convert from legacy ask and bid orders to the new schema causes the output
+    // binary to be too large.  Temporarily disabling match reports removes enough code to make the
+    // contract deployable.  This is an unfortunate compromise to allow this migration to take place.
+    // If the migration occurs quickly enough, though, it shouldn't be an issue...  This functionality
+    // is not currently used by any downstream consumers as of the time of writing, so its removal
+    // is not damaging to any functionality that relies upon it
+    ContractError::generic_error("match reports are currently disabled").to_err()
+    // let ask_order_result = get_ask_order_by_id(deps.storage, &ask_id);
+    // let bid_order_result = get_bid_order_by_id(deps.storage, &bid_id);
+    // if ask_order_result.is_err() || bid_order_result.is_err() {
+    //     return MatchReport::new_missing_order(
+    //         ask_id,
+    //         bid_id,
+    //         ask_order_result.is_ok(),
+    //         bid_order_result.is_ok(),
+    //     )?
+    //     .to_binary();
+    // }
+    // let ask_order = ask_order_result.unwrap();
+    // let bid_order = bid_order_result.unwrap();
+    // let standard_match_result = validate_match(&deps, &ask_order, &bid_order, false);
+    // let quote_mismatch_result = validate_match(&deps, &ask_order, &bid_order, true);
+    // let mut error_messages = vec![];
+    // if let Err(e) = &standard_match_result {
+    //     error_messages.push(format!("Standard match fails due to: {:?}", e))
+    // }
+    // if let Err(e) = &quote_mismatch_result {
+    //     error_messages.push(format!(
+    //         "Quote mismatch-enabled match fails due to: {:?}",
+    //         e
+    //     ))
+    // }
+    // MatchReport::new_existing_orders(
+    //     ask_id,
+    //     bid_id,
+    //     standard_match_result.is_ok(),
+    //     quote_mismatch_result.is_ok(),
+    //     &error_messages,
+    // )
+    // .to_binary()
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::query::get_match_report::get_match_report;
-    use crate::storage::ask_order_storage::insert_ask_order;
-    use crate::storage::bid_order_storage::insert_bid_order;
-    use crate::test::cosmos_type_helpers::MockOwnedDeps;
-    use crate::test::mock_scope::DEFAULT_SCOPE_ID;
-    use crate::test::request_helpers::{mock_ask_order, mock_bid_order, mock_bid_scope_trade};
-    use crate::types::request::ask_types::ask_collateral::AskCollateral;
-    use crate::types::request::bid_types::bid_collateral::BidCollateral;
-    use crate::types::request::match_report::MatchReport;
-    use cosmwasm_std::{coins, from_binary};
-    use provwasm_mocks::mock_dependencies;
-
-    #[test]
-    fn test_missing_orders_report() {
-        let mut deps = mock_dependencies(&[]);
-        let missing_both_report = deserialize_report(&deps, "ask_id", "bid_id");
-        assert!(
-            !missing_both_report.ask_exists,
-            "the ask should not be marked as existing",
-        );
-        assert!(
-            !missing_both_report.bid_exists,
-            "the bid should not be marked as existing",
-        );
-        assert_report_includes_single_error(
-            &missing_both_report,
-            "AskOrder [ask_id] and BidOrder [bid_id] were missing from contract storage",
-        );
-        let ask_order = mock_ask_order(AskCollateral::coin_trade(&[], &[]));
-        insert_ask_order(deps.as_mut().storage, &ask_order)
-            .expect("expected the ask order to be inserted");
-        let bid_order = mock_bid_order(BidCollateral::coin_trade(&[], &[]));
-        insert_bid_order(deps.as_mut().storage, &bid_order)
-            .expect("expected the bid order to be inserted");
-        let missing_ask_report = deserialize_report(&deps, "not_ask", "bid_id");
-        assert!(
-            !missing_ask_report.ask_exists,
-            "the ask should not be marked as existing"
-        );
-        assert!(
-            missing_ask_report.bid_exists,
-            "the bid should be marked as existing"
-        );
-        assert_report_includes_single_error(
-            &missing_ask_report,
-            "AskOrder [not_ask] was missing from contract storage",
-        );
-        let missing_bid_report = deserialize_report(&deps, "ask_id", "not_bid");
-        assert!(
-            missing_bid_report.ask_exists,
-            "the ask should be marked as existing",
-        );
-        assert!(
-            !missing_bid_report.bid_exists,
-            "the bid should not be marked as existing",
-        );
-        assert_report_includes_single_error(
-            &missing_bid_report,
-            "BidOrder [not_bid] was missing from contract storage",
-        );
-    }
-
-    #[test]
-    fn test_standard_match_failure_only() {
-        let mut deps = mock_dependencies(&[]);
-        let base = coins(100, "base");
-        let ask_order = mock_ask_order(AskCollateral::coin_trade(&base, &coins(100, "quote")));
-        insert_ask_order(deps.as_mut().storage, &ask_order).expect("ask should be inserted");
-        let bid_order = mock_bid_order(BidCollateral::coin_trade(&base, &coins(99, "quote")));
-        insert_bid_order(deps.as_mut().storage, &bid_order).expect("bid should be inserted");
-        let report = deserialize_report(&deps, "ask_id", "bid_id");
-        assert!(report.ask_exists, "the ask should be marked as existing",);
-        assert!(report.bid_exists, "the bid should be marked as existing",);
-        assert!(
-            !report.standard_match_possible,
-            "the standard match possible report param should indicate false",
-        );
-        assert!(
-            report.quote_mismatch_match_possible,
-            "the quote mismatch match possible report param should indicate true",
-        );
-        assert_eq!(
-            1,
-            report.error_messages.len(),
-            "the report should have a single error message",
-        );
-        assert!(
-            report
-                .error_messages
-                .first()
-                .unwrap()
-                .contains("Standard match fails due to"),
-            "the failing message should indicate the reason for the mismatched standard match",
-        );
-    }
-
-    #[test]
-    fn test_both_match_types_failure() {
-        let mut deps = mock_dependencies(&[]);
-        let ask_order = mock_ask_order(AskCollateral::coin_trade(
-            &coins(100, "base"),
-            &coins(100, "quote"),
-        ));
-        insert_ask_order(deps.as_mut().storage, &ask_order).expect("ask should be inserted");
-        let bid_order =
-            mock_bid_order(mock_bid_scope_trade(DEFAULT_SCOPE_ID, &coins(100, "quote")));
-        insert_bid_order(deps.as_mut().storage, &bid_order).expect("bid should be inserted");
-        let report = deserialize_report(&deps, "ask_id", "bid_id");
-        assert!(report.ask_exists, "the ask should be marked as existing");
-        assert!(report.bid_exists, "the bid should be marked as existing");
-        assert!(
-            !report.standard_match_possible,
-            "the standard match possible report param should indicate false",
-        );
-        assert!(
-            !report.quote_mismatch_match_possible,
-            "the quote mismatch match possible report param should indicate false",
-        );
-        assert_eq!(
-            2,
-            report.error_messages.len(),
-            "the report should include two error messages",
-        );
-        assert!(
-            report
-                .error_messages
-                .iter()
-                .any(|message| message.contains("Standard match fails due to")),
-            "a message should indicate the reason that a standard match cannot be completed",
-        );
-        assert!(
-            report
-                .error_messages
-                .iter()
-                .any(|message| message.contains("Quote mismatch-enabled match fails due to")),
-            "a message should indicate the reason that a quote mismatch match cannot be completed",
-        );
-    }
-
-    #[test]
-    fn test_successful_match_report() {
-        let mut deps = mock_dependencies(&[]);
-        let base = coins(100, "base");
-        let quote = coins(100, "quote");
-        let ask_order = mock_ask_order(AskCollateral::coin_trade(&base, &quote));
-        insert_ask_order(deps.as_mut().storage, &ask_order).expect("ask should be inserted");
-        let bid_order = mock_bid_order(BidCollateral::coin_trade(&base, &quote));
-        insert_bid_order(deps.as_mut().storage, &bid_order).expect("bid should be inserted");
-        let report = deserialize_report(&deps, "ask_id", "bid_id");
-        assert!(report.ask_exists, "the ask should be marked as existing");
-        assert!(report.bid_exists, "the bid should be marked as existing");
-        assert!(
-            report.standard_match_possible,
-            "the report should indicate that a standard match is possible",
-        );
-        assert!(
-            report.quote_mismatch_match_possible,
-            "the report should indicate that a quote mismatch match is possible",
-        );
-        assert!(
-            report.error_messages.is_empty(),
-            "the report should not include any error messages",
-        );
-    }
-
-    fn deserialize_report<A: Into<String>, B: Into<String>>(
-        deps: &MockOwnedDeps,
-        ask_id: A,
-        bid_id: B,
-    ) -> MatchReport {
-        let ask_id = ask_id.into();
-        let bid_id = bid_id.into();
-        let binary = get_match_report(deps.as_ref(), ask_id.clone(), bid_id.clone())
-            .expect("expected a report to be produced");
-        let report = from_binary::<MatchReport>(&binary)
-            .expect("expected the binary to deserialize to a match report");
-        assert_eq!(
-            ask_id, report.ask_id,
-            "sanity check: ask id should match the input value",
-        );
-        assert_eq!(
-            bid_id, report.bid_id,
-            "sanity check: bid id should match the input value",
-        );
-        report
-    }
-
-    fn assert_report_includes_single_error<S: Into<String>>(
-        report: &MatchReport,
-        expected_error_message: S,
-    ) {
-        assert_eq!(
-            1,
-            report.error_messages.len(),
-            "expected only a single error message to be included in the match report",
-        );
-        assert_eq!(
-            &expected_error_message.into(),
-            report.error_messages.first().unwrap(),
-            "expected the error message in the report to be the correct text",
-        );
-    }
+    // use crate::query::get_match_report::get_match_report;
+    // use crate::storage::ask_order_storage::insert_ask_order;
+    // use crate::storage::bid_order_storage::insert_bid_order;
+    // use crate::test::cosmos_type_helpers::MockOwnedDeps;
+    // use crate::test::mock_scope::DEFAULT_SCOPE_ID;
+    // use crate::test::request_helpers::{mock_ask_order, mock_bid_order, mock_bid_scope_trade};
+    // use crate::types::request::ask_types::ask_collateral::AskCollateral;
+    // use crate::types::request::bid_types::bid_collateral::BidCollateral;
+    // use crate::types::request::match_report::MatchReport;
+    // use cosmwasm_std::{coins, from_binary};
+    // use provwasm_mocks::mock_dependencies;
+    //
+    // #[test]
+    // fn test_missing_orders_report() {
+    //     let mut deps = mock_dependencies(&[]);
+    //     let missing_both_report = deserialize_report(&deps, "ask_id", "bid_id");
+    //     assert!(
+    //         !missing_both_report.ask_exists,
+    //         "the ask should not be marked as existing",
+    //     );
+    //     assert!(
+    //         !missing_both_report.bid_exists,
+    //         "the bid should not be marked as existing",
+    //     );
+    //     assert_report_includes_single_error(
+    //         &missing_both_report,
+    //         "AskOrder [ask_id] and BidOrder [bid_id] were missing from contract storage",
+    //     );
+    //     let ask_order = mock_ask_order(AskCollateral::coin_trade(&[], &[]));
+    //     insert_ask_order(deps.as_mut().storage, &ask_order)
+    //         .expect("expected the ask order to be inserted");
+    //     let bid_order = mock_bid_order(BidCollateral::coin_trade(&[], &[]));
+    //     insert_bid_order(deps.as_mut().storage, &bid_order)
+    //         .expect("expected the bid order to be inserted");
+    //     let missing_ask_report = deserialize_report(&deps, "not_ask", "bid_id");
+    //     assert!(
+    //         !missing_ask_report.ask_exists,
+    //         "the ask should not be marked as existing"
+    //     );
+    //     assert!(
+    //         missing_ask_report.bid_exists,
+    //         "the bid should be marked as existing"
+    //     );
+    //     assert_report_includes_single_error(
+    //         &missing_ask_report,
+    //         "AskOrder [not_ask] was missing from contract storage",
+    //     );
+    //     let missing_bid_report = deserialize_report(&deps, "ask_id", "not_bid");
+    //     assert!(
+    //         missing_bid_report.ask_exists,
+    //         "the ask should be marked as existing",
+    //     );
+    //     assert!(
+    //         !missing_bid_report.bid_exists,
+    //         "the bid should not be marked as existing",
+    //     );
+    //     assert_report_includes_single_error(
+    //         &missing_bid_report,
+    //         "BidOrder [not_bid] was missing from contract storage",
+    //     );
+    // }
+    //
+    // #[test]
+    // fn test_standard_match_failure_only() {
+    //     let mut deps = mock_dependencies(&[]);
+    //     let base = coins(100, "base");
+    //     let ask_order = mock_ask_order(AskCollateral::coin_trade(&base, &coins(100, "quote")));
+    //     insert_ask_order(deps.as_mut().storage, &ask_order).expect("ask should be inserted");
+    //     let bid_order = mock_bid_order(BidCollateral::coin_trade(&base, &coins(99, "quote")));
+    //     insert_bid_order(deps.as_mut().storage, &bid_order).expect("bid should be inserted");
+    //     let report = deserialize_report(&deps, "ask_id", "bid_id");
+    //     assert!(report.ask_exists, "the ask should be marked as existing",);
+    //     assert!(report.bid_exists, "the bid should be marked as existing",);
+    //     assert!(
+    //         !report.standard_match_possible,
+    //         "the standard match possible report param should indicate false",
+    //     );
+    //     assert!(
+    //         report.quote_mismatch_match_possible,
+    //         "the quote mismatch match possible report param should indicate true",
+    //     );
+    //     assert_eq!(
+    //         1,
+    //         report.error_messages.len(),
+    //         "the report should have a single error message",
+    //     );
+    //     assert!(
+    //         report
+    //             .error_messages
+    //             .first()
+    //             .unwrap()
+    //             .contains("Standard match fails due to"),
+    //         "the failing message should indicate the reason for the mismatched standard match",
+    //     );
+    // }
+    //
+    // #[test]
+    // fn test_both_match_types_failure() {
+    //     let mut deps = mock_dependencies(&[]);
+    //     let ask_order = mock_ask_order(AskCollateral::coin_trade(
+    //         &coins(100, "base"),
+    //         &coins(100, "quote"),
+    //     ));
+    //     insert_ask_order(deps.as_mut().storage, &ask_order).expect("ask should be inserted");
+    //     let bid_order =
+    //         mock_bid_order(mock_bid_scope_trade(DEFAULT_SCOPE_ID, &coins(100, "quote")));
+    //     insert_bid_order(deps.as_mut().storage, &bid_order).expect("bid should be inserted");
+    //     let report = deserialize_report(&deps, "ask_id", "bid_id");
+    //     assert!(report.ask_exists, "the ask should be marked as existing");
+    //     assert!(report.bid_exists, "the bid should be marked as existing");
+    //     assert!(
+    //         !report.standard_match_possible,
+    //         "the standard match possible report param should indicate false",
+    //     );
+    //     assert!(
+    //         !report.quote_mismatch_match_possible,
+    //         "the quote mismatch match possible report param should indicate false",
+    //     );
+    //     assert_eq!(
+    //         2,
+    //         report.error_messages.len(),
+    //         "the report should include two error messages",
+    //     );
+    //     assert!(
+    //         report
+    //             .error_messages
+    //             .iter()
+    //             .any(|message| message.contains("Standard match fails due to")),
+    //         "a message should indicate the reason that a standard match cannot be completed",
+    //     );
+    //     assert!(
+    //         report
+    //             .error_messages
+    //             .iter()
+    //             .any(|message| message.contains("Quote mismatch-enabled match fails due to")),
+    //         "a message should indicate the reason that a quote mismatch match cannot be completed",
+    //     );
+    // }
+    //
+    // #[test]
+    // fn test_successful_match_report() {
+    //     let mut deps = mock_dependencies(&[]);
+    //     let base = coins(100, "base");
+    //     let quote = coins(100, "quote");
+    //     let ask_order = mock_ask_order(AskCollateral::coin_trade(&base, &quote));
+    //     insert_ask_order(deps.as_mut().storage, &ask_order).expect("ask should be inserted");
+    //     let bid_order = mock_bid_order(BidCollateral::coin_trade(&base, &quote));
+    //     insert_bid_order(deps.as_mut().storage, &bid_order).expect("bid should be inserted");
+    //     let report = deserialize_report(&deps, "ask_id", "bid_id");
+    //     assert!(report.ask_exists, "the ask should be marked as existing");
+    //     assert!(report.bid_exists, "the bid should be marked as existing");
+    //     assert!(
+    //         report.standard_match_possible,
+    //         "the report should indicate that a standard match is possible",
+    //     );
+    //     assert!(
+    //         report.quote_mismatch_match_possible,
+    //         "the report should indicate that a quote mismatch match is possible",
+    //     );
+    //     assert!(
+    //         report.error_messages.is_empty(),
+    //         "the report should not include any error messages",
+    //     );
+    // }
+    //
+    // fn deserialize_report<A: Into<String>, B: Into<String>>(
+    //     deps: &MockOwnedDeps,
+    //     ask_id: A,
+    //     bid_id: B,
+    // ) -> MatchReport {
+    //     let ask_id = ask_id.into();
+    //     let bid_id = bid_id.into();
+    //     let binary = get_match_report(deps.as_ref(), ask_id.clone(), bid_id.clone())
+    //         .expect("expected a report to be produced");
+    //     let report = from_binary::<MatchReport>(&binary)
+    //         .expect("expected the binary to deserialize to a match report");
+    //     assert_eq!(
+    //         ask_id, report.ask_id,
+    //         "sanity check: ask id should match the input value",
+    //     );
+    //     assert_eq!(
+    //         bid_id, report.bid_id,
+    //         "sanity check: bid id should match the input value",
+    //     );
+    //     report
+    // }
+    //
+    // fn assert_report_includes_single_error<S: Into<String>>(
+    //     report: &MatchReport,
+    //     expected_error_message: S,
+    // ) {
+    //     assert_eq!(
+    //         1,
+    //         report.error_messages.len(),
+    //         "expected only a single error message to be included in the match report",
+    //     );
+    //     assert_eq!(
+    //         &expected_error_message.into(),
+    //         report.error_messages.first().unwrap(),
+    //         "expected the error message in the report to be the correct text",
+    //     );
+    // }
 }

--- a/smart-contract/src/query/get_match_report.rs
+++ b/smart-contract/src/query/get_match_report.rs
@@ -8,6 +8,7 @@ pub fn get_match_report(
     _ask_id: String,
     _bid_id: String,
 ) -> Result<Binary, ContractError> {
+    // TODO: Re-enable this code once the legacy migration has been completed
     // The code required to convert from legacy ask and bid orders to the new schema causes the output
     // binary to be too large.  Temporarily disabling match reports removes enough code to make the
     // contract deployable.  This is an unfortunate compromise to allow this migration to take place.

--- a/smart-contract/src/storage/ask_order_storage.rs
+++ b/smart-contract/src/storage/ask_order_storage.rs
@@ -141,11 +141,12 @@ mod tests {
     };
     use crate::test::mock_marker::DEFAULT_MARKER_DENOM;
     use crate::test::request_helpers::{
-        mock_ask_marker_share_single, mock_ask_marker_trade, mock_ask_order, mock_ask_scope_trade,
+        mock_ask_marker_share_sale, mock_ask_marker_trade, mock_ask_order, mock_ask_scope_trade,
     };
     use crate::types::core::error::ContractError;
     use crate::types::request::ask_types::ask_collateral::AskCollateral;
     use crate::types::request::ask_types::ask_order::AskOrder;
+    use crate::types::request::share_sale_type::ShareSaleType;
     use cosmwasm_std::{coins, Addr};
     use provwasm_mocks::mock_dependencies;
 
@@ -172,7 +173,7 @@ mod tests {
             "expected a secondary insert to be rejected because the marker denoms match",
         );
         if let AskCollateral::MarkerTrade(ref mut collateral) = order.collateral {
-            collateral.address = Addr::unchecked("marker-address-2");
+            collateral.marker_address = Addr::unchecked("marker-address-2");
         }
         insert_ask_order(deps.as_mut().storage, &order)
             .expect("expected the insert to succeed when the ask did not violate any indices");
@@ -270,12 +271,13 @@ mod tests {
         );
         let marker_share_sale_order = AskOrder {
             id: "marker_share_sale".to_string(),
-            ..mock_ask_order(mock_ask_marker_share_single(
+            ..mock_ask_order(mock_ask_marker_share_sale(
                 "marker_share_sale_address",
                 DEFAULT_MARKER_DENOM,
                 100,
-                &[],
                 50,
+                &[],
+                ShareSaleType::MultipleTransactions,
             ))
         };
         test_collateral_id(

--- a/smart-contract/src/storage/legacy_ask_order_storage.rs
+++ b/smart-contract/src/storage/legacy_ask_order_storage.rs
@@ -1,0 +1,55 @@
+use crate::types::core::error::ContractError;
+use crate::types::request::ask_types::ask_order::AskOrder;
+use crate::types::request::ask_types::legacy_ask_order::LegacyAskOrder;
+use crate::util::extensions::ResultExtensions;
+use cosmwasm_std::{Order, Storage};
+use cw_storage_plus::{Index, IndexList, IndexedMap, MultiIndex, UniqueIndex};
+
+const NAMESPACE_ASK_PK: &str = "ask";
+const NAMESPACE_COLLATERAL_IDX: &str = "ask__collateral";
+const NAMESPACE_OWNER_IDX: &str = "ask__owner";
+const NAMESPACE_TYPE_IDX: &str = "ask__type";
+
+pub struct LegacyAskOrderIndices<'a> {
+    pub collateral_index: UniqueIndex<'a, String, LegacyAskOrder>,
+    pub owner_index: MultiIndex<'a, String, LegacyAskOrder, String>,
+    pub type_index: MultiIndex<'a, String, LegacyAskOrder, String>,
+}
+impl<'a> IndexList<LegacyAskOrder> for LegacyAskOrderIndices<'a> {
+    fn get_indexes(&'_ self) -> Box<dyn Iterator<Item = &'_ dyn Index<LegacyAskOrder>> + '_> {
+        let v: Vec<&dyn Index<LegacyAskOrder>> =
+            vec![&self.collateral_index, &self.owner_index, &self.type_index];
+        Box::new(v.into_iter())
+    }
+}
+
+pub fn legacy_ask_orders<'a>() -> IndexedMap<'a, &'a [u8], LegacyAskOrder, LegacyAskOrderIndices<'a>>
+{
+    let indices = LegacyAskOrderIndices {
+        collateral_index: UniqueIndex::new(
+            |ask: &LegacyAskOrder| ask.get_collateral_index(),
+            NAMESPACE_COLLATERAL_IDX,
+        ),
+        owner_index: MultiIndex::new(
+            |ask: &LegacyAskOrder| ask.owner.clone().to_string(),
+            NAMESPACE_ASK_PK,
+            NAMESPACE_OWNER_IDX,
+        ),
+        type_index: MultiIndex::new(
+            |ask: &LegacyAskOrder| ask.ask_type.get_name().to_string(),
+            NAMESPACE_ASK_PK,
+            NAMESPACE_TYPE_IDX,
+        ),
+    };
+    IndexedMap::new(NAMESPACE_ASK_PK, indices)
+}
+
+pub fn get_converted_legacy_ask_orders(
+    storage: &mut dyn Storage,
+) -> Result<Vec<AskOrder>, ContractError> {
+    let mut converted_ask_orders = vec![];
+    for result in legacy_ask_orders().range(storage, None, None, Order::Descending) {
+        converted_ask_orders.push(result?.1.to_new_ask_order());
+    }
+    converted_ask_orders.to_ok()
+}

--- a/smart-contract/src/storage/legacy_bid_order_storage.rs
+++ b/smart-contract/src/storage/legacy_bid_order_storage.rs
@@ -1,0 +1,48 @@
+use crate::types::core::error::ContractError;
+use crate::types::request::bid_types::bid_order::BidOrder;
+use crate::types::request::bid_types::legacy_bid_order::LegacyBidOrder;
+use crate::util::extensions::ResultExtensions;
+use cosmwasm_std::{Order, Storage};
+use cw_storage_plus::{Index, IndexList, IndexedMap, MultiIndex};
+
+const NAMESPACE_BID_PK: &str = "bid";
+const NAMESPACE_OWNER_IDX: &str = "bid__owner";
+const NAMESPACE_TYPE_IDX: &str = "bid__type";
+
+pub struct LegacyBidOrderIndices<'a> {
+    pub owner_index: MultiIndex<'a, String, LegacyBidOrder, String>,
+    pub type_index: MultiIndex<'a, String, LegacyBidOrder, String>,
+}
+impl<'a> IndexList<LegacyBidOrder> for LegacyBidOrderIndices<'a> {
+    fn get_indexes(&'_ self) -> Box<dyn Iterator<Item = &'_ dyn Index<LegacyBidOrder>> + '_> {
+        let v: Vec<&dyn Index<LegacyBidOrder>> = vec![&self.owner_index, &self.type_index];
+        Box::new(v.into_iter())
+    }
+}
+
+pub fn legacy_bid_orders<'a>() -> IndexedMap<'a, &'a [u8], LegacyBidOrder, LegacyBidOrderIndices<'a>>
+{
+    let indices = LegacyBidOrderIndices {
+        owner_index: MultiIndex::new(
+            |bid: &LegacyBidOrder| bid.owner.clone().to_string(),
+            NAMESPACE_BID_PK,
+            NAMESPACE_OWNER_IDX,
+        ),
+        type_index: MultiIndex::new(
+            |bid: &LegacyBidOrder| bid.bid_type.get_name().to_string(),
+            NAMESPACE_BID_PK,
+            NAMESPACE_TYPE_IDX,
+        ),
+    };
+    IndexedMap::new(NAMESPACE_BID_PK, indices)
+}
+
+pub fn get_converted_legacy_bid_orders(
+    storage: &mut dyn Storage,
+) -> Result<Vec<BidOrder>, ContractError> {
+    let mut converted_bid_orders = vec![];
+    for result in legacy_bid_orders().range(storage, None, None, Order::Descending) {
+        converted_bid_orders.push(result?.1.to_new_bid_order());
+    }
+    converted_bid_orders.to_ok()
+}

--- a/smart-contract/src/storage/mod.rs
+++ b/smart-contract/src/storage/mod.rs
@@ -1,5 +1,7 @@
 pub mod ask_order_storage;
 pub mod bid_order_storage;
 pub mod contract_info;
+pub mod legacy_ask_order_storage;
+pub mod legacy_bid_order_storage;
 pub mod order_indices;
 pub mod order_search_repository;

--- a/smart-contract/src/test/request_helpers.rs
+++ b/smart-contract/src/test/request_helpers.rs
@@ -98,43 +98,25 @@ pub fn mock_ask_marker_trade<S1: Into<String>, S2: Into<String>>(
     )
 }
 
-pub fn mock_ask_marker_share_single<S1: Into<String>, S2: Into<String>>(
+pub fn mock_ask_marker_share_sale<S1: Into<String>, S2: Into<String>>(
     addr: S1,
     denom: S2,
-    remaining_shares: u128,
+    total_shares_to_sell: u128,
+    remaining_shares_to_sell: u128,
     share_quote: &[Coin],
-    share_sale_amount: u128,
+    share_sale_type: ShareSaleType,
 ) -> AskCollateral {
     AskCollateral::marker_share_sale(
         Addr::unchecked(addr),
         denom,
-        remaining_shares,
+        total_shares_to_sell,
+        remaining_shares_to_sell,
         share_quote,
         &[AccessGrant {
             address: Addr::unchecked("asker"),
             permissions: vec![MarkerAccess::Admin],
         }],
-        ShareSaleType::single(share_sale_amount),
-    )
-}
-
-pub fn mock_ask_marker_share_multi<S1: Into<String>, S2: Into<String>>(
-    addr: S1,
-    denom: S2,
-    remaining_shares: u128,
-    share_quote: &[Coin],
-    sale_cutoff: Option<u128>,
-) -> AskCollateral {
-    AskCollateral::marker_share_sale(
-        Addr::unchecked(addr),
-        denom,
-        remaining_shares,
-        share_quote,
-        &[AccessGrant {
-            address: Addr::unchecked("asker"),
-            permissions: vec![MarkerAccess::Admin],
-        }],
-        ShareSaleType::multiple(sale_cutoff),
+        share_sale_type,
     )
 }
 

--- a/smart-contract/src/types/core/msg.rs
+++ b/smart-contract/src/types/core/msg.rs
@@ -58,4 +58,5 @@ pub enum QueryMsg {
 #[serde(rename_all = "snake_case")]
 pub enum MigrateMsg {
     ContractUpgrade {},
+    MigrateLegacyOrders {},
 }

--- a/smart-contract/src/types/request/ask_types/ask.rs
+++ b/smart-contract/src/types/request/ask_types/ask.rs
@@ -1,5 +1,5 @@
 use crate::types::request::share_sale_type::ShareSaleType;
-use cosmwasm_std::Coin;
+use cosmwasm_std::{Coin, Uint128};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -18,21 +18,23 @@ impl Ask {
 
     pub fn new_marker_trade<S1: Into<String>, S2: Into<String>>(
         id: S1,
-        denom: S2,
+        marker_denom: S2,
         quote_per_share: &[Coin],
     ) -> Self {
-        Self::MarkerTrade(MarkerTradeAsk::new(id, denom, quote_per_share))
+        Self::MarkerTrade(MarkerTradeAsk::new(id, marker_denom, quote_per_share))
     }
 
     pub fn new_marker_share_sale<S1: Into<String>, S2: Into<String>>(
         id: S1,
-        denom: S2,
+        marker_denom: S2,
+        shares_to_sell: u128,
         quote_per_share: &[Coin],
         share_sale_type: ShareSaleType,
     ) -> Self {
         Self::MarkerShareSale(MarkerShareSaleAsk::new(
             id,
-            denom,
+            marker_denom,
+            shares_to_sell,
             quote_per_share,
             share_sale_type,
         ))
@@ -79,18 +81,18 @@ impl CoinTradeAsk {
 #[serde(rename_all = "snake_case")]
 pub struct MarkerTradeAsk {
     pub id: String,
-    pub denom: String,
+    pub marker_denom: String,
     pub quote_per_share: Vec<Coin>,
 }
 impl MarkerTradeAsk {
     pub fn new<S1: Into<String>, S2: Into<String>>(
         id: S1,
-        denom: S2,
+        marker_denom: S2,
         quote_per_share: &[Coin],
     ) -> Self {
         Self {
             id: id.into(),
-            denom: denom.into(),
+            marker_denom: marker_denom.into(),
             quote_per_share: quote_per_share.to_owned(),
         }
     }
@@ -100,20 +102,23 @@ impl MarkerTradeAsk {
 #[serde(rename_all = "snake_case")]
 pub struct MarkerShareSaleAsk {
     pub id: String,
-    pub denom: String,
+    pub marker_denom: String,
+    pub shares_to_sell: Uint128,
     pub quote_per_share: Vec<Coin>,
     pub share_sale_type: ShareSaleType,
 }
 impl MarkerShareSaleAsk {
     pub fn new<S1: Into<String>, S2: Into<String>>(
         id: S1,
-        denom: S2,
+        marker_denom: S2,
+        shares_to_sell: u128,
         quote_per_share: &[Coin],
         share_sale_type: ShareSaleType,
     ) -> Self {
         Self {
             id: id.into(),
-            denom: denom.into(),
+            marker_denom: marker_denom.into(),
+            shares_to_sell: Uint128::new(shares_to_sell),
             quote_per_share: quote_per_share.to_owned(),
             share_sale_type,
         }

--- a/smart-contract/src/types/request/ask_types/ask_order.rs
+++ b/smart-contract/src/types/request/ask_types/ask_order.rs
@@ -53,9 +53,9 @@ impl AskOrder {
             // Coin trades have no metadata involved - just use self.id as a duplicate index
             AskCollateral::CoinTrade(_) => self.id.clone(),
             // Marker trades include a marker address - only one ask per marker should be created at a time
-            AskCollateral::MarkerTrade(collateral) => collateral.address.to_string(),
+            AskCollateral::MarkerTrade(collateral) => collateral.marker_address.to_string(),
             // Marker trades include a marker address - only one ask per marker should be created at a time
-            AskCollateral::MarkerShareSale(collateral) => collateral.address.to_string(),
+            AskCollateral::MarkerShareSale(collateral) => collateral.marker_address.to_string(),
             // Scope trades include a scope address - only one ask per scope should be created at a time
             AskCollateral::ScopeTrade(collateral) => collateral.scope_address.to_owned(),
         }

--- a/smart-contract/src/types/request/ask_types/legacy_ask_collateral.rs
+++ b/smart-contract/src/types/request/ask_types/legacy_ask_collateral.rs
@@ -1,13 +1,10 @@
-use crate::types::core::error::ContractError;
 use crate::types::request::legacy_share_sale_type::LegacyShareSaleType;
-use crate::util::extensions::ResultExtensions;
 use cosmwasm_std::{Addr, Coin, Uint128};
 use provwasm_std::AccessGrant;
-use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 // TODO: Remove this after type migrations have occurred
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum LegacyAskCollateral {
     CoinTrade(LegacyCoinTradeAskCollateral),
@@ -15,96 +12,15 @@ pub enum LegacyAskCollateral {
     MarkerShareSale(LegacyMarkerShareSaleAskCollateral),
     ScopeTrade(LegacyScopeTradeAskCollateral),
 }
-impl LegacyAskCollateral {
-    pub fn coin_trade(base: &[Coin], quote: &[Coin]) -> Self {
-        Self::CoinTrade(LegacyCoinTradeAskCollateral::new(base, quote))
-    }
 
-    pub fn marker_trade<S: Into<String>>(
-        address: Addr,
-        denom: S,
-        share_count: u128,
-        quote_per_share: &[Coin],
-        removed_permissions: &[AccessGrant],
-    ) -> Self {
-        Self::MarkerTrade(LegacyMarkerTradeAskCollateral::new(
-            address,
-            denom,
-            share_count,
-            quote_per_share,
-            removed_permissions,
-        ))
-    }
-
-    pub fn marker_share_sale<S: Into<String>>(
-        address: Addr,
-        denom: S,
-        remaining_shares: u128,
-        quote_per_share: &[Coin],
-        removed_permissions: &[AccessGrant],
-        sale_type: LegacyShareSaleType,
-    ) -> Self {
-        Self::MarkerShareSale(LegacyMarkerShareSaleAskCollateral::new(
-            address,
-            denom,
-            remaining_shares,
-            quote_per_share,
-            removed_permissions,
-            sale_type,
-        ))
-    }
-
-    pub fn scope_trade<S: Into<String>>(scope_address: S, quote: &[Coin]) -> Self {
-        Self::ScopeTrade(LegacyScopeTradeAskCollateral::new(scope_address, quote))
-    }
-
-    pub fn get_coin_trade(&self) -> Result<&LegacyCoinTradeAskCollateral, ContractError> {
-        match self {
-            LegacyAskCollateral::CoinTrade(collateral) => collateral.to_ok(),
-            _ => ContractError::invalid_type("expected coin trade ask collateral").to_err(),
-        }
-    }
-
-    pub fn get_marker_trade(&self) -> Result<&LegacyMarkerTradeAskCollateral, ContractError> {
-        match self {
-            LegacyAskCollateral::MarkerTrade(collateral) => collateral.to_ok(),
-            _ => ContractError::invalid_type("expected marker trade ask collateral").to_err(),
-        }
-    }
-
-    pub fn get_marker_share_sale(
-        &self,
-    ) -> Result<&LegacyMarkerShareSaleAskCollateral, ContractError> {
-        match self {
-            LegacyAskCollateral::MarkerShareSale(collateral) => collateral.to_ok(),
-            _ => ContractError::invalid_type("expected marker share sale ask collateral").to_err(),
-        }
-    }
-
-    pub fn get_scope_trade(&self) -> Result<&LegacyScopeTradeAskCollateral, ContractError> {
-        match self {
-            LegacyAskCollateral::ScopeTrade(collateral) => collateral.to_ok(),
-            _ => ContractError::invalid_type("expected scope trade ask collateral").to_err(),
-        }
-    }
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct LegacyCoinTradeAskCollateral {
     pub base: Vec<Coin>,
     pub quote: Vec<Coin>,
 }
-impl LegacyCoinTradeAskCollateral {
-    fn new(base: &[Coin], quote: &[Coin]) -> Self {
-        Self {
-            base: base.to_owned(),
-            quote: quote.to_owned(),
-        }
-    }
-}
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct LegacyMarkerTradeAskCollateral {
     pub address: Addr,
@@ -113,25 +29,8 @@ pub struct LegacyMarkerTradeAskCollateral {
     pub quote_per_share: Vec<Coin>,
     pub removed_permissions: Vec<AccessGrant>,
 }
-impl LegacyMarkerTradeAskCollateral {
-    fn new<S: Into<String>>(
-        address: Addr,
-        denom: S,
-        share_count: u128,
-        quote_per_share: &[Coin],
-        removed_permissions: &[AccessGrant],
-    ) -> Self {
-        Self {
-            address,
-            denom: denom.into(),
-            share_count: Uint128::new(share_count),
-            quote_per_share: quote_per_share.to_owned(),
-            removed_permissions: removed_permissions.to_owned(),
-        }
-    }
-}
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct LegacyMarkerShareSaleAskCollateral {
     pub address: Addr,
@@ -141,37 +40,10 @@ pub struct LegacyMarkerShareSaleAskCollateral {
     pub removed_permissions: Vec<AccessGrant>,
     pub sale_type: LegacyShareSaleType,
 }
-impl LegacyMarkerShareSaleAskCollateral {
-    fn new<S: Into<String>>(
-        address: Addr,
-        denom: S,
-        remaining_shares: u128,
-        quote_per_share: &[Coin],
-        removed_permissions: &[AccessGrant],
-        sale_type: LegacyShareSaleType,
-    ) -> Self {
-        Self {
-            address,
-            denom: denom.into(),
-            remaining_shares: Uint128::new(remaining_shares),
-            quote_per_share: quote_per_share.to_owned(),
-            removed_permissions: removed_permissions.to_owned(),
-            sale_type,
-        }
-    }
-}
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct LegacyScopeTradeAskCollateral {
     pub scope_address: String,
     pub quote: Vec<Coin>,
-}
-impl LegacyScopeTradeAskCollateral {
-    fn new<S: Into<String>>(scope_address: S, quote: &[Coin]) -> Self {
-        Self {
-            scope_address: scope_address.into(),
-            quote: quote.to_owned(),
-        }
-    }
 }

--- a/smart-contract/src/types/request/ask_types/legacy_ask_collateral.rs
+++ b/smart-contract/src/types/request/ask_types/legacy_ask_collateral.rs
@@ -1,5 +1,5 @@
 use crate::types::core::error::ContractError;
-use crate::types::request::share_sale_type::ShareSaleType;
+use crate::types::request::legacy_share_sale_type::LegacyShareSaleType;
 use crate::util::extensions::ResultExtensions;
 use cosmwasm_std::{Addr, Coin, Uint128};
 use provwasm_std::AccessGrant;
@@ -42,7 +42,7 @@ impl LegacyAskCollateral {
         remaining_shares: u128,
         quote_per_share: &[Coin],
         removed_permissions: &[AccessGrant],
-        sale_type: ShareSaleType,
+        sale_type: LegacyShareSaleType,
     ) -> Self {
         Self::MarkerShareSale(LegacyMarkerShareSaleAskCollateral::new(
             address,
@@ -139,7 +139,7 @@ pub struct LegacyMarkerShareSaleAskCollateral {
     pub remaining_shares: Uint128,
     pub quote_per_share: Vec<Coin>,
     pub removed_permissions: Vec<AccessGrant>,
-    pub sale_type: ShareSaleType,
+    pub sale_type: LegacyShareSaleType,
 }
 impl LegacyMarkerShareSaleAskCollateral {
     fn new<S: Into<String>>(
@@ -148,7 +148,7 @@ impl LegacyMarkerShareSaleAskCollateral {
         remaining_shares: u128,
         quote_per_share: &[Coin],
         removed_permissions: &[AccessGrant],
-        sale_type: ShareSaleType,
+        sale_type: LegacyShareSaleType,
     ) -> Self {
         Self {
             address,

--- a/smart-contract/src/types/request/ask_types/legacy_ask_order.rs
+++ b/smart-contract/src/types/request/ask_types/legacy_ask_order.rs
@@ -1,7 +1,14 @@
+use crate::types::request::ask_types::ask_collateral::{
+    AskCollateral, CoinTradeAskCollateral, MarkerShareSaleAskCollateral, MarkerTradeAskCollateral,
+    ScopeTradeAskCollateral,
+};
+use crate::types::request::ask_types::ask_order::AskOrder;
 use crate::types::request::ask_types::legacy_ask_collateral::LegacyAskCollateral;
+use crate::types::request::legacy_share_sale_type::LegacyShareSaleType;
 use crate::types::request::request_descriptor::RequestDescriptor;
 use crate::types::request::request_type::RequestType;
-use cosmwasm_std::Addr;
+use crate::types::request::share_sale_type::ShareSaleType;
+use cosmwasm_std::{Addr, Uint128};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -31,5 +38,317 @@ impl LegacyAskOrder {
             // Scope trades include a scope address - only one ask per scope should be created at a time
             LegacyAskCollateral::ScopeTrade(collateral) => collateral.scope_address.to_owned(),
         }
+    }
+
+    pub fn to_new_ask_order(self) -> AskOrder {
+        AskOrder {
+            id: self.id,
+            ask_type: self.ask_type,
+            owner: self.owner,
+            collateral: match self.collateral {
+                LegacyAskCollateral::CoinTrade(collateral) => {
+                    AskCollateral::CoinTrade(CoinTradeAskCollateral {
+                        base: collateral.base,
+                        quote: collateral.quote,
+                    })
+                }
+                LegacyAskCollateral::MarkerTrade(collateral) => {
+                    AskCollateral::MarkerTrade(MarkerTradeAskCollateral {
+                        marker_address: collateral.address,
+                        marker_denom: collateral.denom,
+                        share_count: collateral.share_count,
+                        quote_per_share: collateral.quote_per_share,
+                        removed_permissions: collateral.removed_permissions,
+                    })
+                }
+                LegacyAskCollateral::MarkerShareSale(collateral) => {
+                    let (share_count, sale_type) = match collateral.sale_type {
+                        LegacyShareSaleType::SingleTransaction { share_count } => {
+                            (share_count, ShareSaleType::SingleTransaction)
+                        }
+                        LegacyShareSaleType::MultipleTransactions {
+                            remove_sale_share_threshold,
+                        } => (
+                            Uint128::new(
+                                collateral.remaining_shares.u128()
+                                    - remove_sale_share_threshold.map(|t| t.u128()).unwrap_or(0),
+                            ),
+                            ShareSaleType::MultipleTransactions,
+                        ),
+                    };
+                    AskCollateral::MarkerShareSale(MarkerShareSaleAskCollateral {
+                        marker_address: collateral.address,
+                        marker_denom: collateral.denom,
+                        total_shares_in_sale: share_count,
+                        remaining_shares_in_sale: share_count,
+                        quote_per_share: collateral.quote_per_share,
+                        removed_permissions: collateral.removed_permissions,
+                        sale_type,
+                    })
+                }
+                LegacyAskCollateral::ScopeTrade(collateral) => {
+                    AskCollateral::ScopeTrade(ScopeTradeAskCollateral {
+                        scope_address: collateral.scope_address,
+                        quote: collateral.quote,
+                    })
+                }
+            },
+            descriptor: self.descriptor,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::mock_scope::DEFAULT_SCOPE_ID;
+    use crate::types::request::ask_types::ask_order::AskOrder;
+    use crate::types::request::ask_types::legacy_ask_collateral::LegacyAskCollateral;
+    use crate::types::request::ask_types::legacy_ask_order::LegacyAskOrder;
+    use crate::types::request::legacy_share_sale_type::LegacyShareSaleType;
+    use crate::types::request::request_descriptor::{AttributeRequirement, RequestDescriptor};
+    use crate::types::request::request_type::RequestType;
+    use crate::types::request::share_sale_type::ShareSaleType;
+    use cosmwasm_std::{coins, Addr, Uint128};
+    use provwasm_std::{AccessGrant, MarkerAccess};
+
+    #[test]
+    fn test_successful_conversion_for_coin_trade() {
+        let legacy_coin_trade = LegacyAskOrder {
+            id: "ask_id".to_string(),
+            ask_type: RequestType::CoinTrade,
+            owner: Addr::unchecked("asker"),
+            collateral: LegacyAskCollateral::coin_trade(&coins(100, "base"), &coins(100, "quote")),
+            descriptor: Some(RequestDescriptor::new_populated_attributes(
+                "description",
+                AttributeRequirement::any(&["your", "face"]),
+            )),
+        };
+        let new_coin_trade = legacy_coin_trade.clone().to_new_ask_order();
+        assert_base_equality_in_ask_orders(&legacy_coin_trade, &new_coin_trade);
+        let legacy_collateral = match legacy_coin_trade.collateral {
+            LegacyAskCollateral::CoinTrade(collateral) => collateral,
+            _ => panic!("unexpected legacy coin trade ask collateral"),
+        };
+        let new_collateral = new_coin_trade.collateral.unwrap_coin_trade();
+        assert_eq!(legacy_collateral.quote, new_collateral.quote);
+        assert_eq!(legacy_collateral.base, new_collateral.base);
+    }
+
+    #[test]
+    fn test_successful_conversion_for_marker_trade() {
+        let legacy_marker_trade = LegacyAskOrder {
+            id: "ask_id".to_string(),
+            ask_type: RequestType::MarkerTrade,
+            owner: Addr::unchecked("asker"),
+            collateral: LegacyAskCollateral::marker_trade(
+                Addr::unchecked("markeraddress"),
+                "markerdenom",
+                10,
+                &coins(100, "quote"),
+                &[AccessGrant {
+                    permissions: vec![MarkerAccess::Admin],
+                    address: Addr::unchecked("someperson"),
+                }],
+            ),
+            descriptor: Some(RequestDescriptor::new_populated_attributes(
+                "description",
+                AttributeRequirement::any(&["your", "face"]),
+            )),
+        };
+        let new_marker_trade = legacy_marker_trade.clone().to_new_ask_order();
+        assert_base_equality_in_ask_orders(&legacy_marker_trade, &new_marker_trade);
+        let legacy_collateral = match legacy_marker_trade.collateral {
+            LegacyAskCollateral::MarkerTrade(collateral) => collateral,
+            _ => panic!("unexpected legacy marker trade ask collateral"),
+        };
+        let new_collateral = new_marker_trade.collateral.unwrap_marker_trade();
+        assert_eq!(legacy_collateral.address, new_collateral.marker_address);
+        assert_eq!(legacy_collateral.denom, new_collateral.marker_denom);
+        assert_eq!(legacy_collateral.share_count, new_collateral.share_count);
+        assert_eq!(
+            legacy_collateral.quote_per_share,
+            new_collateral.quote_per_share
+        );
+        assert_eq!(
+            legacy_collateral.removed_permissions,
+            new_collateral.removed_permissions
+        );
+    }
+
+    #[test]
+    fn test_successful_conversion_for_marker_share_sale_single_tx() {
+        let legacy_marker_share_sale = LegacyAskOrder {
+            id: "ask_id".to_string(),
+            ask_type: RequestType::MarkerShareSale,
+            owner: Addr::unchecked("asker"),
+            collateral: LegacyAskCollateral::marker_share_sale(
+                Addr::unchecked("markeraddress"),
+                "markerdenom",
+                10,
+                &coins(100, "quote"),
+                &[AccessGrant {
+                    permissions: vec![MarkerAccess::Admin],
+                    address: Addr::unchecked("someperson"),
+                }],
+                LegacyShareSaleType::SingleTransaction {
+                    share_count: Uint128::new(10),
+                },
+            ),
+            descriptor: Some(RequestDescriptor::new_populated_attributes(
+                "description",
+                AttributeRequirement::any(&["your", "face"]),
+            )),
+        };
+        let new_marker_share_sale = legacy_marker_share_sale.clone().to_new_ask_order();
+        assert_base_equality_in_ask_orders(&legacy_marker_share_sale, &new_marker_share_sale);
+        let legacy_collateral = match legacy_marker_share_sale.collateral {
+            LegacyAskCollateral::MarkerShareSale(collateral) => collateral,
+            _ => panic!("unexpected legacy marker share sale ask collateral"),
+        };
+        let new_collateral = new_marker_share_sale.collateral.unwrap_marker_share_sale();
+        assert_eq!(legacy_collateral.address, new_collateral.marker_address);
+        assert_eq!(legacy_collateral.denom, new_collateral.marker_denom);
+        assert_eq!(10, new_collateral.total_shares_in_sale.u128());
+        assert_eq!(10, new_collateral.remaining_shares_in_sale.u128());
+        assert_eq!(
+            legacy_collateral.quote_per_share,
+            new_collateral.quote_per_share
+        );
+        assert_eq!(
+            legacy_collateral.removed_permissions,
+            new_collateral.removed_permissions
+        );
+        assert_eq!(ShareSaleType::SingleTransaction, new_collateral.sale_type);
+    }
+
+    #[test]
+    fn test_successful_conversion_for_marker_share_sale_multi_tx_with_threshold() {
+        let legacy_marker_share_sale = LegacyAskOrder {
+            id: "ask_id".to_string(),
+            ask_type: RequestType::MarkerShareSale,
+            owner: Addr::unchecked("asker"),
+            collateral: LegacyAskCollateral::marker_share_sale(
+                Addr::unchecked("markeraddress"),
+                "markerdenom",
+                10,
+                &coins(100, "quote"),
+                &[AccessGrant {
+                    permissions: vec![MarkerAccess::Admin],
+                    address: Addr::unchecked("someperson"),
+                }],
+                LegacyShareSaleType::MultipleTransactions {
+                    remove_sale_share_threshold: Some(Uint128::new(7)),
+                },
+            ),
+            descriptor: Some(RequestDescriptor::new_populated_attributes(
+                "description",
+                AttributeRequirement::any(&["your", "face"]),
+            )),
+        };
+        let new_marker_share_sale = legacy_marker_share_sale.clone().to_new_ask_order();
+        assert_base_equality_in_ask_orders(&legacy_marker_share_sale, &new_marker_share_sale);
+        let legacy_collateral = match legacy_marker_share_sale.collateral {
+            LegacyAskCollateral::MarkerShareSale(collateral) => collateral,
+            _ => panic!("unexpected legacy marker share sale ask collateral"),
+        };
+        let new_collateral = new_marker_share_sale.collateral.unwrap_marker_share_sale();
+        assert_eq!(legacy_collateral.address, new_collateral.marker_address);
+        assert_eq!(legacy_collateral.denom, new_collateral.marker_denom);
+        assert_eq!(3, new_collateral.total_shares_in_sale.u128());
+        assert_eq!(3, new_collateral.remaining_shares_in_sale.u128());
+        assert_eq!(
+            legacy_collateral.quote_per_share,
+            new_collateral.quote_per_share
+        );
+        assert_eq!(
+            legacy_collateral.removed_permissions,
+            new_collateral.removed_permissions
+        );
+        assert_eq!(
+            ShareSaleType::MultipleTransactions,
+            new_collateral.sale_type
+        );
+    }
+
+    #[test]
+    fn test_successful_conversion_for_marker_share_sale_multi_tx_without_threshold() {
+        let legacy_marker_share_sale = LegacyAskOrder {
+            id: "ask_id".to_string(),
+            ask_type: RequestType::MarkerShareSale,
+            owner: Addr::unchecked("asker"),
+            collateral: LegacyAskCollateral::marker_share_sale(
+                Addr::unchecked("markeraddress"),
+                "markerdenom",
+                15,
+                &coins(100, "quote"),
+                &[AccessGrant {
+                    permissions: vec![MarkerAccess::Admin],
+                    address: Addr::unchecked("someperson"),
+                }],
+                LegacyShareSaleType::MultipleTransactions {
+                    remove_sale_share_threshold: None,
+                },
+            ),
+            descriptor: Some(RequestDescriptor::new_populated_attributes(
+                "description",
+                AttributeRequirement::any(&["your", "face"]),
+            )),
+        };
+        let new_marker_share_sale = legacy_marker_share_sale.clone().to_new_ask_order();
+        assert_base_equality_in_ask_orders(&legacy_marker_share_sale, &new_marker_share_sale);
+        let legacy_collateral = match legacy_marker_share_sale.collateral {
+            LegacyAskCollateral::MarkerShareSale(collateral) => collateral,
+            _ => panic!("unexpected legacy marker share sale ask collateral"),
+        };
+        let new_collateral = new_marker_share_sale.collateral.unwrap_marker_share_sale();
+        assert_eq!(legacy_collateral.address, new_collateral.marker_address);
+        assert_eq!(legacy_collateral.denom, new_collateral.marker_denom);
+        assert_eq!(15, new_collateral.total_shares_in_sale.u128());
+        assert_eq!(15, new_collateral.remaining_shares_in_sale.u128());
+        assert_eq!(
+            legacy_collateral.quote_per_share,
+            new_collateral.quote_per_share
+        );
+        assert_eq!(
+            legacy_collateral.removed_permissions,
+            new_collateral.removed_permissions
+        );
+        assert_eq!(
+            ShareSaleType::MultipleTransactions,
+            new_collateral.sale_type
+        );
+    }
+
+    #[test]
+    fn test_successful_conversion_for_scope_trade() {
+        let legacy_scope_trade = LegacyAskOrder {
+            id: "ask_id".to_string(),
+            ask_type: RequestType::ScopeTrade,
+            owner: Addr::unchecked("asker"),
+            collateral: LegacyAskCollateral::scope_trade(DEFAULT_SCOPE_ID, &coins(100, "quote")),
+            descriptor: Some(RequestDescriptor::new_populated_attributes(
+                "description",
+                AttributeRequirement::any(&["your", "face"]),
+            )),
+        };
+        let new_scope_trade = legacy_scope_trade.clone().to_new_ask_order();
+        assert_base_equality_in_ask_orders(&legacy_scope_trade, &new_scope_trade);
+        let legacy_collateral = match legacy_scope_trade.collateral {
+            LegacyAskCollateral::ScopeTrade(collateral) => collateral,
+            _ => panic!("unexpected legacy scope trade ask collateral"),
+        };
+        let new_collateral = new_scope_trade.collateral.unwrap_scope_trade();
+        assert_eq!(
+            legacy_collateral.scope_address,
+            new_collateral.scope_address
+        );
+        assert_eq!(legacy_collateral.quote, new_collateral.quote);
+    }
+
+    fn assert_base_equality_in_ask_orders(legacy_order: &LegacyAskOrder, new_order: &AskOrder) {
+        assert_eq!(legacy_order.id, new_order.id);
+        assert_eq!(legacy_order.ask_type, new_order.ask_type);
+        assert_eq!(legacy_order.owner, new_order.owner);
+        assert_eq!(legacy_order.descriptor, new_order.descriptor);
     }
 }

--- a/smart-contract/src/types/request/ask_types/legacy_ask_order.rs
+++ b/smart-contract/src/types/request/ask_types/legacy_ask_order.rs
@@ -9,11 +9,10 @@ use crate::types::request::request_descriptor::RequestDescriptor;
 use crate::types::request::request_type::RequestType;
 use crate::types::request::share_sale_type::ShareSaleType;
 use cosmwasm_std::{Addr, Uint128};
-use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 // TODO: Remove this after type migrations have occurred
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct LegacyAskOrder {
     pub id: String,
@@ -102,7 +101,10 @@ impl LegacyAskOrder {
 mod tests {
     use crate::test::mock_scope::DEFAULT_SCOPE_ID;
     use crate::types::request::ask_types::ask_order::AskOrder;
-    use crate::types::request::ask_types::legacy_ask_collateral::LegacyAskCollateral;
+    use crate::types::request::ask_types::legacy_ask_collateral::{
+        LegacyAskCollateral, LegacyCoinTradeAskCollateral, LegacyMarkerShareSaleAskCollateral,
+        LegacyMarkerTradeAskCollateral, LegacyScopeTradeAskCollateral,
+    };
     use crate::types::request::ask_types::legacy_ask_order::LegacyAskOrder;
     use crate::types::request::legacy_share_sale_type::LegacyShareSaleType;
     use crate::types::request::request_descriptor::{AttributeRequirement, RequestDescriptor};
@@ -117,7 +119,10 @@ mod tests {
             id: "ask_id".to_string(),
             ask_type: RequestType::CoinTrade,
             owner: Addr::unchecked("asker"),
-            collateral: LegacyAskCollateral::coin_trade(&coins(100, "base"), &coins(100, "quote")),
+            collateral: LegacyAskCollateral::CoinTrade(LegacyCoinTradeAskCollateral {
+                base: coins(100, "base"),
+                quote: coins(100, "quote"),
+            }),
             descriptor: Some(RequestDescriptor::new_populated_attributes(
                 "description",
                 AttributeRequirement::any(&["your", "face"]),
@@ -140,16 +145,16 @@ mod tests {
             id: "ask_id".to_string(),
             ask_type: RequestType::MarkerTrade,
             owner: Addr::unchecked("asker"),
-            collateral: LegacyAskCollateral::marker_trade(
-                Addr::unchecked("markeraddress"),
-                "markerdenom",
-                10,
-                &coins(100, "quote"),
-                &[AccessGrant {
+            collateral: LegacyAskCollateral::MarkerTrade(LegacyMarkerTradeAskCollateral {
+                address: Addr::unchecked("markeraddress"),
+                denom: "markerdenom".to_string(),
+                share_count: Uint128::new(10),
+                quote_per_share: coins(100, "quote"),
+                removed_permissions: vec![AccessGrant {
                     permissions: vec![MarkerAccess::Admin],
                     address: Addr::unchecked("someperson"),
                 }],
-            ),
+            }),
             descriptor: Some(RequestDescriptor::new_populated_attributes(
                 "description",
                 AttributeRequirement::any(&["your", "face"]),
@@ -181,19 +186,19 @@ mod tests {
             id: "ask_id".to_string(),
             ask_type: RequestType::MarkerShareSale,
             owner: Addr::unchecked("asker"),
-            collateral: LegacyAskCollateral::marker_share_sale(
-                Addr::unchecked("markeraddress"),
-                "markerdenom",
-                10,
-                &coins(100, "quote"),
-                &[AccessGrant {
+            collateral: LegacyAskCollateral::MarkerShareSale(LegacyMarkerShareSaleAskCollateral {
+                address: Addr::unchecked("markeraddress"),
+                denom: "markerdenom".to_string(),
+                remaining_shares: Uint128::new(10),
+                quote_per_share: coins(100, "quote"),
+                removed_permissions: vec![AccessGrant {
                     permissions: vec![MarkerAccess::Admin],
                     address: Addr::unchecked("someperson"),
                 }],
-                LegacyShareSaleType::SingleTransaction {
+                sale_type: LegacyShareSaleType::SingleTransaction {
                     share_count: Uint128::new(10),
                 },
-            ),
+            }),
             descriptor: Some(RequestDescriptor::new_populated_attributes(
                 "description",
                 AttributeRequirement::any(&["your", "face"]),
@@ -227,19 +232,19 @@ mod tests {
             id: "ask_id".to_string(),
             ask_type: RequestType::MarkerShareSale,
             owner: Addr::unchecked("asker"),
-            collateral: LegacyAskCollateral::marker_share_sale(
-                Addr::unchecked("markeraddress"),
-                "markerdenom",
-                10,
-                &coins(100, "quote"),
-                &[AccessGrant {
+            collateral: LegacyAskCollateral::MarkerShareSale(LegacyMarkerShareSaleAskCollateral {
+                address: Addr::unchecked("markeraddress"),
+                denom: "markerdenom".to_string(),
+                remaining_shares: Uint128::new(10),
+                quote_per_share: coins(100, "quote"),
+                removed_permissions: vec![AccessGrant {
                     permissions: vec![MarkerAccess::Admin],
                     address: Addr::unchecked("someperson"),
                 }],
-                LegacyShareSaleType::MultipleTransactions {
+                sale_type: LegacyShareSaleType::MultipleTransactions {
                     remove_sale_share_threshold: Some(Uint128::new(7)),
                 },
-            ),
+            }),
             descriptor: Some(RequestDescriptor::new_populated_attributes(
                 "description",
                 AttributeRequirement::any(&["your", "face"]),
@@ -276,19 +281,19 @@ mod tests {
             id: "ask_id".to_string(),
             ask_type: RequestType::MarkerShareSale,
             owner: Addr::unchecked("asker"),
-            collateral: LegacyAskCollateral::marker_share_sale(
-                Addr::unchecked("markeraddress"),
-                "markerdenom",
-                15,
-                &coins(100, "quote"),
-                &[AccessGrant {
+            collateral: LegacyAskCollateral::MarkerShareSale(LegacyMarkerShareSaleAskCollateral {
+                address: Addr::unchecked("markeraddress"),
+                denom: "markerdenom".to_string(),
+                remaining_shares: Uint128::new(15),
+                quote_per_share: coins(100, "quote"),
+                removed_permissions: vec![AccessGrant {
                     permissions: vec![MarkerAccess::Admin],
                     address: Addr::unchecked("someperson"),
                 }],
-                LegacyShareSaleType::MultipleTransactions {
+                sale_type: LegacyShareSaleType::MultipleTransactions {
                     remove_sale_share_threshold: None,
                 },
-            ),
+            }),
             descriptor: Some(RequestDescriptor::new_populated_attributes(
                 "description",
                 AttributeRequirement::any(&["your", "face"]),
@@ -325,7 +330,10 @@ mod tests {
             id: "ask_id".to_string(),
             ask_type: RequestType::ScopeTrade,
             owner: Addr::unchecked("asker"),
-            collateral: LegacyAskCollateral::scope_trade(DEFAULT_SCOPE_ID, &coins(100, "quote")),
+            collateral: LegacyAskCollateral::ScopeTrade(LegacyScopeTradeAskCollateral {
+                scope_address: DEFAULT_SCOPE_ID.to_string(),
+                quote: coins(100, "quote"),
+            }),
             descriptor: Some(RequestDescriptor::new_populated_attributes(
                 "description",
                 AttributeRequirement::any(&["your", "face"]),

--- a/smart-contract/src/types/request/ask_types/legacy_ask_order.rs
+++ b/smart-contract/src/types/request/ask_types/legacy_ask_order.rs
@@ -1,0 +1,35 @@
+use crate::types::request::ask_types::legacy_ask_collateral::LegacyAskCollateral;
+use crate::types::request::request_descriptor::RequestDescriptor;
+use crate::types::request::request_type::RequestType;
+use cosmwasm_std::Addr;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+// TODO: Remove this after type migrations have occurred
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct LegacyAskOrder {
+    pub id: String,
+    pub ask_type: RequestType,
+    pub owner: Addr,
+    pub collateral: LegacyAskCollateral,
+    pub descriptor: Option<RequestDescriptor>,
+}
+impl LegacyAskOrder {
+    pub fn get_pk(&self) -> &[u8] {
+        self.id.as_bytes()
+    }
+
+    pub fn get_collateral_index(&self) -> String {
+        match &self.collateral {
+            // Coin trades have no metadata involved - just use self.id as a duplicate index
+            LegacyAskCollateral::CoinTrade(_) => self.id.clone(),
+            // Marker trades include a marker address - only one ask per marker should be created at a time
+            LegacyAskCollateral::MarkerTrade(collateral) => collateral.address.to_string(),
+            // Marker trades include a marker address - only one ask per marker should be created at a time
+            LegacyAskCollateral::MarkerShareSale(collateral) => collateral.address.to_string(),
+            // Scope trades include a scope address - only one ask per scope should be created at a time
+            LegacyAskCollateral::ScopeTrade(collateral) => collateral.scope_address.to_owned(),
+        }
+    }
+}

--- a/smart-contract/src/types/request/ask_types/mod.rs
+++ b/smart-contract/src/types/request/ask_types/mod.rs
@@ -1,3 +1,5 @@
 pub mod ask;
 pub mod ask_collateral;
 pub mod ask_order;
+pub mod legacy_ask_collateral;
+pub mod legacy_ask_order;

--- a/smart-contract/src/types/request/bid_types/bid.rs
+++ b/smart-contract/src/types/request/bid_types/bid.rs
@@ -15,16 +15,16 @@ impl Bid {
         Self::CoinTrade(CoinTradeBid::new(id, base))
     }
 
-    pub fn new_marker_trade<S1: Into<String>, S2: Into<String>>(id: S1, denom: S2) -> Self {
-        Self::MarkerTrade(MarkerTradeBid::new(id, denom))
+    pub fn new_marker_trade<S1: Into<String>, S2: Into<String>>(id: S1, marker_denom: S2) -> Self {
+        Self::MarkerTrade(MarkerTradeBid::new(id, marker_denom))
     }
 
     pub fn new_marker_share_sale<S1: Into<String>, S2: Into<String>>(
         id: S1,
-        denom: S2,
+        marker_denom: S2,
         share_count: u128,
     ) -> Self {
-        Self::MarkerShareSale(MarkerShareSaleBid::new(id, denom, share_count))
+        Self::MarkerShareSale(MarkerShareSaleBid::new(id, marker_denom, share_count))
     }
 
     pub fn new_scope_trade<S1: Into<String>, S2: Into<String>>(id: S1, scope_address: S2) -> Self {
@@ -64,13 +64,13 @@ impl CoinTradeBid {
 #[serde(rename_all = "snake_case")]
 pub struct MarkerTradeBid {
     pub id: String,
-    pub denom: String,
+    pub marker_denom: String,
 }
 impl MarkerTradeBid {
-    pub fn new<S1: Into<String>, S2: Into<String>>(id: S1, denom: S2) -> Self {
+    pub fn new<S1: Into<String>, S2: Into<String>>(id: S1, marker_denom: S2) -> Self {
         Self {
             id: id.into(),
-            denom: denom.into(),
+            marker_denom: marker_denom.into(),
         }
     }
 }
@@ -79,14 +79,18 @@ impl MarkerTradeBid {
 #[serde(rename_all = "snake_case")]
 pub struct MarkerShareSaleBid {
     pub id: String,
-    pub denom: String,
+    pub marker_denom: String,
     pub share_count: Uint128,
 }
 impl MarkerShareSaleBid {
-    pub fn new<S1: Into<String>, S2: Into<String>>(id: S1, denom: S2, share_count: u128) -> Self {
+    pub fn new<S1: Into<String>, S2: Into<String>>(
+        id: S1,
+        marker_denom: S2,
+        share_count: u128,
+    ) -> Self {
         Self {
             id: id.into(),
-            denom: denom.into(),
+            marker_denom: marker_denom.into(),
             share_count: Uint128::new(share_count),
         }
     }

--- a/smart-contract/src/types/request/bid_types/bid_collateral.rs
+++ b/smart-contract/src/types/request/bid_types/bid_collateral.rs
@@ -17,19 +17,27 @@ impl BidCollateral {
         Self::CoinTrade(CoinTradeBidCollateral::new(base, quote))
     }
 
-    pub fn marker_trade<S: Into<String>>(address: Addr, denom: S, quote: &[Coin]) -> Self {
-        Self::MarkerTrade(MarkerTradeBidCollateral::new(address, denom, quote))
+    pub fn marker_trade<S: Into<String>>(
+        marker_address: Addr,
+        marker_denom: S,
+        quote: &[Coin],
+    ) -> Self {
+        Self::MarkerTrade(MarkerTradeBidCollateral::new(
+            marker_address,
+            marker_denom,
+            quote,
+        ))
     }
 
     pub fn marker_share_sale<S: Into<String>>(
-        address: Addr,
-        denom: S,
+        marker_address: Addr,
+        marker_denom: S,
         share_count: u128,
         quote: &[Coin],
     ) -> Self {
         Self::MarkerShareSale(MarkerShareSaleBidCollateral::new(
-            address,
-            denom,
+            marker_address,
+            marker_denom,
             share_count,
             quote,
         ))
@@ -86,15 +94,15 @@ impl CoinTradeBidCollateral {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct MarkerTradeBidCollateral {
-    pub address: Addr,
-    pub denom: String,
+    pub marker_address: Addr,
+    pub marker_denom: String,
     pub quote: Vec<Coin>,
 }
 impl MarkerTradeBidCollateral {
-    pub fn new<S: Into<String>>(address: Addr, denom: S, quote: &[Coin]) -> Self {
+    pub fn new<S: Into<String>>(marker_address: Addr, marker_denom: S, quote: &[Coin]) -> Self {
         Self {
-            address,
-            denom: denom.into(),
+            marker_address,
+            marker_denom: marker_denom.into(),
             quote: quote.to_owned(),
         }
     }
@@ -103,21 +111,21 @@ impl MarkerTradeBidCollateral {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct MarkerShareSaleBidCollateral {
-    pub address: Addr,
-    pub denom: String,
+    pub marker_address: Addr,
+    pub marker_denom: String,
     pub share_count: Uint128,
     pub quote: Vec<Coin>,
 }
 impl MarkerShareSaleBidCollateral {
     pub fn new<S: Into<String>>(
-        address: Addr,
-        denom: S,
+        marker_address: Addr,
+        marker_denom: S,
         share_count: u128,
         quote: &[Coin],
     ) -> Self {
         Self {
-            address,
-            denom: denom.into(),
+            marker_address,
+            marker_denom: marker_denom.into(),
             share_count: Uint128::new(share_count),
             quote: quote.to_owned(),
         }

--- a/smart-contract/src/types/request/bid_types/legacy_bid_collateral.rs
+++ b/smart-contract/src/types/request/bid_types/legacy_bid_collateral.rs
@@ -1,0 +1,111 @@
+use cosmwasm_std::{Addr, Coin, Uint128};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+// TODO: Remove this after type migrations have occurred
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum LegacyBidCollateral {
+    CoinTrade(LegacyCoinTradeBidCollateral),
+    MarkerTrade(LegacyMarkerTradeBidCollateral),
+    MarkerShareSale(LegacyMarkerShareSaleBidCollateral),
+    ScopeTrade(LegacyScopeTradeBidCollateral),
+}
+impl LegacyBidCollateral {
+    pub fn coin_trade(base: &[Coin], quote: &[Coin]) -> Self {
+        Self::CoinTrade(LegacyCoinTradeBidCollateral::new(base, quote))
+    }
+
+    pub fn marker_trade<S: Into<String>>(address: Addr, denom: S, quote: &[Coin]) -> Self {
+        Self::MarkerTrade(LegacyMarkerTradeBidCollateral::new(address, denom, quote))
+    }
+
+    pub fn marker_share_sale<S: Into<String>>(
+        address: Addr,
+        denom: S,
+        share_count: u128,
+        quote: &[Coin],
+    ) -> Self {
+        Self::MarkerShareSale(LegacyMarkerShareSaleBidCollateral::new(
+            address,
+            denom,
+            share_count,
+            quote,
+        ))
+    }
+
+    pub fn scope_trade<S: Into<String>>(scope_address: S, quote: &[Coin]) -> Self {
+        Self::ScopeTrade(LegacyScopeTradeBidCollateral::new(scope_address, quote))
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct LegacyCoinTradeBidCollateral {
+    pub base: Vec<Coin>,
+    pub quote: Vec<Coin>,
+}
+impl LegacyCoinTradeBidCollateral {
+    pub fn new(base: &[Coin], quote: &[Coin]) -> Self {
+        Self {
+            base: base.to_owned(),
+            quote: quote.to_owned(),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct LegacyMarkerTradeBidCollateral {
+    pub address: Addr,
+    pub denom: String,
+    pub quote: Vec<Coin>,
+}
+impl LegacyMarkerTradeBidCollateral {
+    pub fn new<S: Into<String>>(address: Addr, denom: S, quote: &[Coin]) -> Self {
+        Self {
+            address,
+            denom: denom.into(),
+            quote: quote.to_owned(),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct LegacyMarkerShareSaleBidCollateral {
+    pub address: Addr,
+    pub denom: String,
+    pub share_count: Uint128,
+    pub quote: Vec<Coin>,
+}
+impl LegacyMarkerShareSaleBidCollateral {
+    pub fn new<S: Into<String>>(
+        address: Addr,
+        denom: S,
+        share_count: u128,
+        quote: &[Coin],
+    ) -> Self {
+        Self {
+            address,
+            denom: denom.into(),
+            share_count: Uint128::new(share_count),
+            quote: quote.to_owned(),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct LegacyScopeTradeBidCollateral {
+    pub scope_address: String,
+    pub quote: Vec<Coin>,
+}
+impl LegacyScopeTradeBidCollateral {
+    pub fn new<S: Into<String>>(scope_address: S, quote: &[Coin]) -> Self {
+        Self {
+            scope_address: scope_address.into(),
+            quote: quote.to_owned(),
+        }
+    }
+}

--- a/smart-contract/src/types/request/bid_types/legacy_bid_collateral.rs
+++ b/smart-contract/src/types/request/bid_types/legacy_bid_collateral.rs
@@ -1,9 +1,8 @@
 use cosmwasm_std::{Addr, Coin, Uint128};
-use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 // TODO: Remove this after type migrations have occurred
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum LegacyBidCollateral {
     CoinTrade(LegacyCoinTradeBidCollateral),
@@ -11,67 +10,23 @@ pub enum LegacyBidCollateral {
     MarkerShareSale(LegacyMarkerShareSaleBidCollateral),
     ScopeTrade(LegacyScopeTradeBidCollateral),
 }
-impl LegacyBidCollateral {
-    pub fn coin_trade(base: &[Coin], quote: &[Coin]) -> Self {
-        Self::CoinTrade(LegacyCoinTradeBidCollateral::new(base, quote))
-    }
 
-    pub fn marker_trade<S: Into<String>>(address: Addr, denom: S, quote: &[Coin]) -> Self {
-        Self::MarkerTrade(LegacyMarkerTradeBidCollateral::new(address, denom, quote))
-    }
-
-    pub fn marker_share_sale<S: Into<String>>(
-        address: Addr,
-        denom: S,
-        share_count: u128,
-        quote: &[Coin],
-    ) -> Self {
-        Self::MarkerShareSale(LegacyMarkerShareSaleBidCollateral::new(
-            address,
-            denom,
-            share_count,
-            quote,
-        ))
-    }
-
-    pub fn scope_trade<S: Into<String>>(scope_address: S, quote: &[Coin]) -> Self {
-        Self::ScopeTrade(LegacyScopeTradeBidCollateral::new(scope_address, quote))
-    }
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct LegacyCoinTradeBidCollateral {
     pub base: Vec<Coin>,
     pub quote: Vec<Coin>,
 }
-impl LegacyCoinTradeBidCollateral {
-    pub fn new(base: &[Coin], quote: &[Coin]) -> Self {
-        Self {
-            base: base.to_owned(),
-            quote: quote.to_owned(),
-        }
-    }
-}
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct LegacyMarkerTradeBidCollateral {
     pub address: Addr,
     pub denom: String,
     pub quote: Vec<Coin>,
 }
-impl LegacyMarkerTradeBidCollateral {
-    pub fn new<S: Into<String>>(address: Addr, denom: S, quote: &[Coin]) -> Self {
-        Self {
-            address,
-            denom: denom.into(),
-            quote: quote.to_owned(),
-        }
-    }
-}
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct LegacyMarkerShareSaleBidCollateral {
     pub address: Addr,
@@ -79,33 +34,10 @@ pub struct LegacyMarkerShareSaleBidCollateral {
     pub share_count: Uint128,
     pub quote: Vec<Coin>,
 }
-impl LegacyMarkerShareSaleBidCollateral {
-    pub fn new<S: Into<String>>(
-        address: Addr,
-        denom: S,
-        share_count: u128,
-        quote: &[Coin],
-    ) -> Self {
-        Self {
-            address,
-            denom: denom.into(),
-            share_count: Uint128::new(share_count),
-            quote: quote.to_owned(),
-        }
-    }
-}
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct LegacyScopeTradeBidCollateral {
     pub scope_address: String,
     pub quote: Vec<Coin>,
-}
-impl LegacyScopeTradeBidCollateral {
-    pub fn new<S: Into<String>>(scope_address: S, quote: &[Coin]) -> Self {
-        Self {
-            scope_address: scope_address.into(),
-            quote: quote.to_owned(),
-        }
-    }
 }

--- a/smart-contract/src/types/request/bid_types/legacy_bid_order.rs
+++ b/smart-contract/src/types/request/bid_types/legacy_bid_order.rs
@@ -1,3 +1,8 @@
+use crate::types::request::bid_types::bid_collateral::{
+    BidCollateral, CoinTradeBidCollateral, MarkerShareSaleBidCollateral, MarkerTradeBidCollateral,
+    ScopeTradeBidCollateral,
+};
+use crate::types::request::bid_types::bid_order::BidOrder;
 use crate::types::request::bid_types::legacy_bid_collateral::LegacyBidCollateral;
 use crate::types::request::request_descriptor::RequestDescriptor;
 use crate::types::request::request_type::RequestType;
@@ -18,5 +23,167 @@ pub struct LegacyBidOrder {
 impl LegacyBidOrder {
     pub fn get_pk(&self) -> &[u8] {
         self.id.as_bytes()
+    }
+
+    pub fn to_new_bid_order(self) -> BidOrder {
+        BidOrder {
+            id: self.id,
+            bid_type: self.bid_type,
+            owner: self.owner,
+            collateral: match self.collateral {
+                LegacyBidCollateral::CoinTrade(collateral) => {
+                    BidCollateral::CoinTrade(CoinTradeBidCollateral {
+                        base: collateral.base,
+                        quote: collateral.quote,
+                    })
+                }
+                LegacyBidCollateral::MarkerTrade(collateral) => {
+                    BidCollateral::MarkerTrade(MarkerTradeBidCollateral {
+                        marker_address: collateral.address,
+                        marker_denom: collateral.denom,
+                        quote: collateral.quote,
+                    })
+                }
+                LegacyBidCollateral::MarkerShareSale(collateral) => {
+                    BidCollateral::MarkerShareSale(MarkerShareSaleBidCollateral {
+                        marker_address: collateral.address,
+                        marker_denom: collateral.denom,
+                        share_count: collateral.share_count,
+                        quote: collateral.quote,
+                    })
+                }
+                LegacyBidCollateral::ScopeTrade(collateral) => {
+                    BidCollateral::ScopeTrade(ScopeTradeBidCollateral {
+                        scope_address: collateral.scope_address,
+                        quote: collateral.quote,
+                    })
+                }
+            },
+            descriptor: self.descriptor,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::types::request::bid_types::bid_order::BidOrder;
+    use crate::types::request::bid_types::legacy_bid_collateral::LegacyBidCollateral;
+    use crate::types::request::bid_types::legacy_bid_order::LegacyBidOrder;
+    use crate::types::request::request_descriptor::{AttributeRequirement, RequestDescriptor};
+    use crate::types::request::request_type::RequestType;
+    use cosmwasm_std::{coins, Addr};
+
+    #[test]
+    fn test_successful_conversion_for_coin_trade() {
+        let legacy_coin_trade = LegacyBidOrder {
+            id: "bid_id".to_string(),
+            bid_type: RequestType::CoinTrade,
+            owner: Addr::unchecked("bidder"),
+            collateral: LegacyBidCollateral::coin_trade(&coins(100, "base"), &coins(100, "quote")),
+            descriptor: Some(RequestDescriptor::new_populated_attributes(
+                "description",
+                AttributeRequirement::all(&["some", "stuff"]),
+            )),
+        };
+        let new_coin_trade = legacy_coin_trade.clone().to_new_bid_order();
+        assert_base_equality_in_bid_orders(&legacy_coin_trade, &new_coin_trade);
+        let legacy_collateral = match legacy_coin_trade.collateral {
+            LegacyBidCollateral::CoinTrade(collateral) => collateral,
+            _ => panic!("unexpected legacy coin trade bid collateral"),
+        };
+        let new_collateral = new_coin_trade.collateral.unwrap_coin_trade();
+        assert_eq!(legacy_collateral.base, new_collateral.base);
+        assert_eq!(legacy_collateral.quote, new_collateral.quote);
+    }
+
+    #[test]
+    fn test_successful_conversion_for_marker_trade() {
+        let legacy_marker_trade = LegacyBidOrder {
+            id: "bid_id".to_string(),
+            bid_type: RequestType::MarkerTrade,
+            owner: Addr::unchecked("bidder"),
+            collateral: LegacyBidCollateral::marker_trade(
+                Addr::unchecked("marker_address"),
+                "markerdenom",
+                &coins(100, "quote"),
+            ),
+            descriptor: Some(RequestDescriptor::new_populated_attributes(
+                "description",
+                AttributeRequirement::all(&["some", "stuff"]),
+            )),
+        };
+        let new_marker_trade = legacy_marker_trade.clone().to_new_bid_order();
+        assert_base_equality_in_bid_orders(&legacy_marker_trade, &new_marker_trade);
+        let legacy_collateral = match legacy_marker_trade.collateral {
+            LegacyBidCollateral::MarkerTrade(collateral) => collateral,
+            _ => panic!("unexpected legacy marker trade bid collateral"),
+        };
+        let new_collateral = new_marker_trade.collateral.unwrap_marker_trade();
+        assert_eq!(legacy_collateral.address, new_collateral.marker_address);
+        assert_eq!(legacy_collateral.denom, new_collateral.marker_denom);
+        assert_eq!(legacy_collateral.quote, new_collateral.quote);
+    }
+
+    #[test]
+    fn test_successful_conversion_for_marker_share_sale() {
+        let legacy_marker_share_sale = LegacyBidOrder {
+            id: "bid_id".to_string(),
+            bid_type: RequestType::MarkerShareSale,
+            owner: Addr::unchecked("bidder"),
+            collateral: LegacyBidCollateral::marker_share_sale(
+                Addr::unchecked("marker_address"),
+                "markerdenom",
+                100,
+                &coins(100, "quote"),
+            ),
+            descriptor: Some(RequestDescriptor::new_populated_attributes(
+                "description",
+                AttributeRequirement::all(&["some", "stuff"]),
+            )),
+        };
+        let new_marker_share_sale = legacy_marker_share_sale.clone().to_new_bid_order();
+        assert_base_equality_in_bid_orders(&legacy_marker_share_sale, &new_marker_share_sale);
+        let legacy_collateral = match legacy_marker_share_sale.collateral {
+            LegacyBidCollateral::MarkerShareSale(collateral) => collateral,
+            _ => panic!("unexpected legacy marker share sale bid collateral"),
+        };
+        let new_collateral = new_marker_share_sale.collateral.unwrap_marker_share_sale();
+        assert_eq!(legacy_collateral.address, new_collateral.marker_address);
+        assert_eq!(legacy_collateral.denom, new_collateral.marker_denom);
+        assert_eq!(legacy_collateral.share_count, new_collateral.share_count);
+        assert_eq!(legacy_collateral.quote, new_collateral.quote);
+    }
+
+    #[test]
+    fn test_successful_conversion_for_scope_trade() {
+        let legacy_scope_trade = LegacyBidOrder {
+            id: "bid_id".to_string(),
+            bid_type: RequestType::ScopeTrade,
+            owner: Addr::unchecked("bidder"),
+            collateral: LegacyBidCollateral::scope_trade("scope address", &coins(100, "quote")),
+            descriptor: Some(RequestDescriptor::new_populated_attributes(
+                "description",
+                AttributeRequirement::all(&["some", "stuff"]),
+            )),
+        };
+        let new_scope_trade = legacy_scope_trade.clone().to_new_bid_order();
+        assert_base_equality_in_bid_orders(&legacy_scope_trade, &new_scope_trade);
+        let legacy_collateral = match legacy_scope_trade.collateral {
+            LegacyBidCollateral::ScopeTrade(collateral) => collateral,
+            _ => panic!("unexpected legacy scope trade bid collateral"),
+        };
+        let new_collateral = new_scope_trade.collateral.unwrap_scope_trade();
+        assert_eq!(
+            legacy_collateral.scope_address,
+            new_collateral.scope_address
+        );
+        assert_eq!(legacy_collateral.quote, new_collateral.quote);
+    }
+
+    fn assert_base_equality_in_bid_orders(legacy_order: &LegacyBidOrder, new_order: &BidOrder) {
+        assert_eq!(legacy_order.id, new_order.id);
+        assert_eq!(legacy_order.bid_type, new_order.bid_type);
+        assert_eq!(legacy_order.owner, new_order.owner);
+        assert_eq!(legacy_order.descriptor, new_order.descriptor);
     }
 }

--- a/smart-contract/src/types/request/bid_types/legacy_bid_order.rs
+++ b/smart-contract/src/types/request/bid_types/legacy_bid_order.rs
@@ -1,0 +1,22 @@
+use crate::types::request::bid_types::legacy_bid_collateral::LegacyBidCollateral;
+use crate::types::request::request_descriptor::RequestDescriptor;
+use crate::types::request::request_type::RequestType;
+use cosmwasm_std::Addr;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+// TODO: Remove this after type migrations have occurred
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct LegacyBidOrder {
+    pub id: String,
+    pub bid_type: RequestType,
+    pub owner: Addr,
+    pub collateral: LegacyBidCollateral,
+    pub descriptor: Option<RequestDescriptor>,
+}
+impl LegacyBidOrder {
+    pub fn get_pk(&self) -> &[u8] {
+        self.id.as_bytes()
+    }
+}

--- a/smart-contract/src/types/request/bid_types/legacy_bid_order.rs
+++ b/smart-contract/src/types/request/bid_types/legacy_bid_order.rs
@@ -7,11 +7,10 @@ use crate::types::request::bid_types::legacy_bid_collateral::LegacyBidCollateral
 use crate::types::request::request_descriptor::RequestDescriptor;
 use crate::types::request::request_type::RequestType;
 use cosmwasm_std::Addr;
-use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 // TODO: Remove this after type migrations have occurred
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct LegacyBidOrder {
     pub id: String,
@@ -67,11 +66,14 @@ impl LegacyBidOrder {
 #[cfg(test)]
 mod tests {
     use crate::types::request::bid_types::bid_order::BidOrder;
-    use crate::types::request::bid_types::legacy_bid_collateral::LegacyBidCollateral;
+    use crate::types::request::bid_types::legacy_bid_collateral::{
+        LegacyBidCollateral, LegacyCoinTradeBidCollateral, LegacyMarkerShareSaleBidCollateral,
+        LegacyMarkerTradeBidCollateral, LegacyScopeTradeBidCollateral,
+    };
     use crate::types::request::bid_types::legacy_bid_order::LegacyBidOrder;
     use crate::types::request::request_descriptor::{AttributeRequirement, RequestDescriptor};
     use crate::types::request::request_type::RequestType;
-    use cosmwasm_std::{coins, Addr};
+    use cosmwasm_std::{coins, Addr, Uint128};
 
     #[test]
     fn test_successful_conversion_for_coin_trade() {
@@ -79,7 +81,10 @@ mod tests {
             id: "bid_id".to_string(),
             bid_type: RequestType::CoinTrade,
             owner: Addr::unchecked("bidder"),
-            collateral: LegacyBidCollateral::coin_trade(&coins(100, "base"), &coins(100, "quote")),
+            collateral: LegacyBidCollateral::CoinTrade(LegacyCoinTradeBidCollateral {
+                base: coins(100, "base"),
+                quote: coins(100, "quote"),
+            }),
             descriptor: Some(RequestDescriptor::new_populated_attributes(
                 "description",
                 AttributeRequirement::all(&["some", "stuff"]),
@@ -102,11 +107,11 @@ mod tests {
             id: "bid_id".to_string(),
             bid_type: RequestType::MarkerTrade,
             owner: Addr::unchecked("bidder"),
-            collateral: LegacyBidCollateral::marker_trade(
-                Addr::unchecked("marker_address"),
-                "markerdenom",
-                &coins(100, "quote"),
-            ),
+            collateral: LegacyBidCollateral::MarkerTrade(LegacyMarkerTradeBidCollateral {
+                address: Addr::unchecked("marker_address"),
+                denom: "markerdenom".to_string(),
+                quote: coins(100, "quote"),
+            }),
             descriptor: Some(RequestDescriptor::new_populated_attributes(
                 "description",
                 AttributeRequirement::all(&["some", "stuff"]),
@@ -130,12 +135,12 @@ mod tests {
             id: "bid_id".to_string(),
             bid_type: RequestType::MarkerShareSale,
             owner: Addr::unchecked("bidder"),
-            collateral: LegacyBidCollateral::marker_share_sale(
-                Addr::unchecked("marker_address"),
-                "markerdenom",
-                100,
-                &coins(100, "quote"),
-            ),
+            collateral: LegacyBidCollateral::MarkerShareSale(LegacyMarkerShareSaleBidCollateral {
+                address: Addr::unchecked("marker_address"),
+                denom: "markerdenom".to_string(),
+                share_count: Uint128::new(100),
+                quote: coins(100, "quote"),
+            }),
             descriptor: Some(RequestDescriptor::new_populated_attributes(
                 "description",
                 AttributeRequirement::all(&["some", "stuff"]),
@@ -160,7 +165,10 @@ mod tests {
             id: "bid_id".to_string(),
             bid_type: RequestType::ScopeTrade,
             owner: Addr::unchecked("bidder"),
-            collateral: LegacyBidCollateral::scope_trade("scope address", &coins(100, "quote")),
+            collateral: LegacyBidCollateral::ScopeTrade(LegacyScopeTradeBidCollateral {
+                scope_address: "scope address".to_string(),
+                quote: coins(100, "quote"),
+            }),
             descriptor: Some(RequestDescriptor::new_populated_attributes(
                 "description",
                 AttributeRequirement::all(&["some", "stuff"]),

--- a/smart-contract/src/types/request/bid_types/mod.rs
+++ b/smart-contract/src/types/request/bid_types/mod.rs
@@ -1,3 +1,5 @@
 pub mod bid;
 pub mod bid_collateral;
 pub mod bid_order;
+pub mod legacy_bid_collateral;
+pub mod legacy_bid_order;

--- a/smart-contract/src/types/request/legacy_share_sale_type.rs
+++ b/smart-contract/src/types/request/legacy_share_sale_type.rs
@@ -1,9 +1,8 @@
 use cosmwasm_std::Uint128;
-use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 // TODO: Remove this after type migrations have occurred
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum LegacyShareSaleType {
     /// Indicates that only a single transaction will be made after an ask of this share type is made.

--- a/smart-contract/src/types/request/legacy_share_sale_type.rs
+++ b/smart-contract/src/types/request/legacy_share_sale_type.rs
@@ -1,13 +1,15 @@
+use cosmwasm_std::Uint128;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+// TODO: Remove this after type migrations have occurred
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
-pub enum ShareSaleType {
+pub enum LegacyShareSaleType {
     /// Indicates that only a single transaction will be made after an ask of this share type is made.
     /// Ex: Asker indicates they want to sell  80 shares of their marker at a certain quote.  The
     /// bidder must buy exactly that many shares.
-    SingleTransaction,
+    SingleTransaction { share_count: Uint128 },
     /// Indicates that multiple transactions can be made after an ask of this share type is made.
     /// Optionally allows the sale to be withdrawn after a certain share count is met.  This
     /// ensures that shares can be purchased many times from the marker, but never more shares than
@@ -17,5 +19,7 @@ pub enum ShareSaleType {
     /// Ex: Asker indicates they want to sell shares of their marker until there are only 10
     /// remaining.  Multiple bids can come in and incrementally buy shares from the marker.  Once
     /// the threshold of 10 remaining shares is hit, the ask will be automatically deleted.
-    MultipleTransactions,
+    MultipleTransactions {
+        remove_sale_share_threshold: Option<Uint128>,
+    },
 }

--- a/smart-contract/src/types/request/match_report.rs
+++ b/smart-contract/src/types/request/match_report.rs
@@ -1,6 +1,3 @@
-use crate::types::core::error::ContractError;
-use crate::util::extensions::ResultExtensions;
-use cosmwasm_std::{to_binary, Binary};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -16,60 +13,60 @@ pub struct MatchReport {
     pub error_messages: Vec<String>,
 }
 impl MatchReport {
-    pub fn new_missing_order<A: Into<String>, B: Into<String>>(
-        ask_id: A,
-        bid_id: B,
-        ask_exists: bool,
-        bid_exists: bool,
-    ) -> Result<Self, ContractError> {
-        let ask_id = ask_id.into();
-        let bid_id = bid_id.into();
-        let error_message = if ask_exists && bid_exists {
-            return ContractError::validation_error(&["created missing order MatchReport with both ask and bid existing. this is a contract bug"]).to_err();
-        } else if ask_exists {
-            format!("BidOrder [{}] was missing from contract storage", &bid_id)
-        } else if bid_exists {
-            format!("AskOrder [{}] was missing from contract storage", &ask_id)
-        } else {
-            format!(
-                "AskOrder [{}] and BidOrder [{}] were missing from contract storage",
-                &ask_id, &bid_id
-            )
-        };
-        Self {
-            ask_id,
-            bid_id,
-            ask_exists,
-            bid_exists,
-            standard_match_possible: false,
-            quote_mismatch_match_possible: false,
-            error_messages: vec![error_message],
-        }
-        .to_ok()
-    }
-
-    pub fn new_existing_orders<A: Into<String>, B: Into<String>, E: Into<String>>(
-        ask_id: A,
-        bid_id: B,
-        standard_match_possible: bool,
-        quote_mismatch_match_possible: bool,
-        error_messages: &[E],
-    ) -> Self
-    where
-        E: Clone,
-    {
-        Self {
-            ask_id: ask_id.into(),
-            bid_id: bid_id.into(),
-            ask_exists: true,
-            bid_exists: true,
-            standard_match_possible,
-            quote_mismatch_match_possible,
-            error_messages: error_messages.iter().cloned().map(|s| s.into()).collect(),
-        }
-    }
-
-    pub fn to_binary(&self) -> Result<Binary, ContractError> {
-        to_binary(self)?.to_ok()
-    }
+    // pub fn new_missing_order<A: Into<String>, B: Into<String>>(
+    //     ask_id: A,
+    //     bid_id: B,
+    //     ask_exists: bool,
+    //     bid_exists: bool,
+    // ) -> Result<Self, ContractError> {
+    //     let ask_id = ask_id.into();
+    //     let bid_id = bid_id.into();
+    //     let error_message = if ask_exists && bid_exists {
+    //         return ContractError::validation_error(&["created missing order MatchReport with both ask and bid existing. this is a contract bug"]).to_err();
+    //     } else if ask_exists {
+    //         format!("BidOrder [{}] was missing from contract storage", &bid_id)
+    //     } else if bid_exists {
+    //         format!("AskOrder [{}] was missing from contract storage", &ask_id)
+    //     } else {
+    //         format!(
+    //             "AskOrder [{}] and BidOrder [{}] were missing from contract storage",
+    //             &ask_id, &bid_id
+    //         )
+    //     };
+    //     Self {
+    //         ask_id,
+    //         bid_id,
+    //         ask_exists,
+    //         bid_exists,
+    //         standard_match_possible: false,
+    //         quote_mismatch_match_possible: false,
+    //         error_messages: vec![error_message],
+    //     }
+    //     .to_ok()
+    // }
+    //
+    // pub fn new_existing_orders<A: Into<String>, B: Into<String>, E: Into<String>>(
+    //     ask_id: A,
+    //     bid_id: B,
+    //     standard_match_possible: bool,
+    //     quote_mismatch_match_possible: bool,
+    //     error_messages: &[E],
+    // ) -> Self
+    // where
+    //     E: Clone,
+    // {
+    //     Self {
+    //         ask_id: ask_id.into(),
+    //         bid_id: bid_id.into(),
+    //         ask_exists: true,
+    //         bid_exists: true,
+    //         standard_match_possible,
+    //         quote_mismatch_match_possible,
+    //         error_messages: error_messages.iter().cloned().map(|s| s.into()).collect(),
+    //     }
+    // }
+    //
+    // pub fn to_binary(&self) -> Result<Binary, ContractError> {
+    //     to_binary(self)?.to_ok()
+    // }
 }

--- a/smart-contract/src/types/request/mod.rs
+++ b/smart-contract/src/types/request/mod.rs
@@ -1,5 +1,6 @@
 pub mod ask_types;
 pub mod bid_types;
+pub mod legacy_share_sale_type;
 pub mod match_report;
 pub mod request_descriptor;
 pub mod request_type;

--- a/smart-contract/src/validation/bid_order_validation.rs
+++ b/smart-contract/src/validation/bid_order_validation.rs
@@ -109,11 +109,11 @@ pub fn validate_bid_order(bid_order: &BidOrder) -> Result<(), ContractError> {
         }
         BidCollateral::MarkerTrade(collateral) => {
             let prefix = format!("BidOrder [{}] of type marker trade", bid_order.id);
-            if collateral.address.as_str().is_empty() {
+            if collateral.marker_address.as_str().is_empty() {
                 invalid_field_messages
                     .push(format!("{} must include a valid marker address", prefix,));
             }
-            if collateral.denom.is_empty() {
+            if collateral.marker_denom.is_empty() {
                 invalid_field_messages
                     .push(format!("{} must include a valid marker denom", prefix,));
             }
@@ -131,11 +131,11 @@ pub fn validate_bid_order(bid_order: &BidOrder) -> Result<(), ContractError> {
         }
         BidCollateral::MarkerShareSale(collateral) => {
             let prefix = format!("BidOrder [{}] of type marker share sale", bid_order.id);
-            if collateral.address.as_str().is_empty() {
+            if collateral.marker_address.as_str().is_empty() {
                 invalid_field_messages
                     .push(format!("{} must include a valid marker address", prefix));
             }
-            if collateral.denom.is_empty() {
+            if collateral.marker_denom.is_empty() {
                 invalid_field_messages
                     .push(format!("{} must include a valid marker denom", prefix));
             }


### PR DESCRIPTION
# Smart Contract Changes
- Bumped contract version to `v1.0.3`
- Added new contract migration route `migrate_legacy_orders`, which takes the old format of `AskOrder` and `BidOrder`, loads it, converts it to the new format, deletes the old reference, and then saves the new reference.
- Created `LegacyAskOrder` and `LegacyBidOrder` and their collateral counterparts to mimic the original design from v1.0.2.
- Various renames in ask/bid structs to use `marker_denom` instead of `denom` and `marker_address` instead of `address`. 
- Added `shares_to_sell` to the `MarkerShareSale` ask struct, ensuring the user can clearly define how many shares will be sold in either single or multiple transaction sales.
- Removed `remaining_shares` from `marker_share_sale` in favor of `total_shares_in_sale`, which is a constant value that never changes, always denoting how many shares are to be sold, and `remaining_shares_in_sale` which denotes the remaining shares in the sale and is decremented with each sale.
- Removed inner values on `ShareSaleType`, ensuring that they are simple enums and do not include additional details.  All of those values are handled directly by the `MarkerShareSale` struct.
- Altered validation across various areas of the contract to ensure the new fields for marker share sale are supported correctly, and altered / added / removed unit tests where relevant to this.
- Completely commented out the `match report` functionality.  This is unused as far as I know, and it must be disabled while this migration runs.  If I keep it in, the contract is too large to be accepted by Provenance WASM size inspection, so I compromised and temp disabled this.  This will be re-enabled as soon as the follow-up v1.0.4 comes out that removes all the legacy types and migration code.

# Kotlin Client Changes
- Various field renames to accommodate changes in the contract.
- `ShareSaleType` has become an `enum class` instead of a `sealed interface` because it now is a simple enum in the contract.
- Removed json examples from `AskOrder` and `BidOrder`, and changed to the new Jackson annotation strategy to collapse their formats.  I missed this one in v1.0.2, sadly.
- Altered the int test script to always re-build the contract.  It's slower, but it makes re-running tests less of a chore when making contract changes in tandem.