### PR TITLE
v1.0.5: QoL and bug fixes

### DIFF
--- a/kotlin-client/src/integrationTest/kotlin/io/provenance/bilateral/contract/QueryIntTest.kt
+++ b/kotlin-client/src/integrationTest/kotlin/io/provenance/bilateral/contract/QueryIntTest.kt
@@ -1,10 +1,13 @@
 package io.provenance.bilateral.contract
 
 import io.provenance.bilateral.execute.CreateAsk
+import io.provenance.bilateral.execute.CreateBid
 import org.junit.jupiter.api.Test
 import testconfiguration.accounts.BilateralAccounts
 import testconfiguration.functions.assertAskExists
 import testconfiguration.functions.assertAskIsDeleted
+import testconfiguration.functions.assertBidExists
+import testconfiguration.functions.assertBidIsDeleted
 import testconfiguration.functions.assertNotNull
 import testconfiguration.functions.assertNull
 import testconfiguration.functions.assertSucceeds
@@ -15,27 +18,42 @@ import kotlin.test.assertFails
 
 class QueryIntTest : ContractIntTest() {
     @Test
-    fun testGetAskByCollateralId() {
-        assertFails("A missing id should cause an exception") { bilateralClient.getAskByCollateralId("some id whatever") }
-        bilateralClient.getAskByCollateralIdOrNull("fakeid").assertNull("The OrNull variant should return null for a missing id")
+    fun testGetAskFunctions() {
+        assertFails("A missing id should cause an exception for getAsk") { bilateralClient.getAsk("some fake ask") }
+        assertFails("A missing id should cause an exception for getAskByCollateralId") { bilateralClient.getAskByCollateralId("some id whatever") }
+        bilateralClient.getAskOrNull("some id or something").assertNull("The OrNull variant of getAsk should return null for a missing id")
+        bilateralClient.getAskByCollateralIdOrNull("fakeid").assertNull("The OrNull variant of getAskByCollateralId should return null for a missing id")
         val coinTradeAskUuid = UUID.randomUUID()
-        testAndCleanupAsk(
-            ask = CreateAsk.newCoinTrade(
-                id = coinTradeAskUuid.toString(),
-                quote = newCoins(100, "nhash"),
-                base = newCoins(150, "nhash"),
-                descriptor = null,
-            ),
-            expectedId = coinTradeAskUuid.toString(),
+        val ask = CreateAsk.newCoinTrade(
+            id = coinTradeAskUuid.toString(),
+            quote = newCoins(100, "nhash"),
+            base = newCoins(150, "nhash"),
+            descriptor = null,
         )
-    }
-
-    private fun testAndCleanupAsk(ask: CreateAsk, expectedId: String) {
         bilateralClient.createAsk(ask, BilateralAccounts.askerAccount)
         bilateralClient.assertAskExists(ask.getId())
-        assertSucceeds("Expected the ask to be available by collateral id") { bilateralClient.getAskByCollateralId(expectedId) }
-        bilateralClient.getAskByCollateralIdOrNull(expectedId).assertNotNull("ask should not be null when fetching by collateral id")
+        bilateralClient.getAskOrNull(ask.getId()).assertNotNull("Ask should exist when fetched by nullable request")
+        assertSucceeds("Expected the ask to be available by collateral id") { bilateralClient.getAskByCollateralId(coinTradeAskUuid.toString()) }
+        bilateralClient.getAskByCollateralIdOrNull(coinTradeAskUuid.toString()).assertNotNull("ask should not be null when fetching by collateral id")
         bilateralClient.cancelAsk(ask.getId(), BilateralAccounts.askerAccount)
         bilateralClient.assertAskIsDeleted(ask.getId())
+    }
+
+    @Test
+    fun testGetBidFunctions() {
+        assertFails("A missing id should cause an exception for getBid") { bilateralClient.getBid("some fake bid") }
+        bilateralClient.getBidOrNull("some id or whatever").assertNull("The OrNull variant of getBid should return null for a missing id")
+        val coinTradeBidUuid = UUID.randomUUID()
+        val bid = CreateBid.newCoinTrade(
+            id = coinTradeBidUuid.toString(),
+            quote = newCoins(100, "nhash"),
+            base = newCoins(150, "nhash"),
+            descriptor = null,
+        )
+        bilateralClient.createBid(bid, BilateralAccounts.bidderAccount)
+        bilateralClient.assertBidExists(bid.getId())
+        bilateralClient.getBidOrNull(bid.getId()).assertNotNull("Bid should exist when fetched by nullable request")
+        bilateralClient.cancelBid(bid.getId(), BilateralAccounts.bidderAccount)
+        bilateralClient.assertBidIsDeleted(bid.getId())
     }
 }

--- a/kotlin-client/src/integrationTest/kotlin/io/provenance/bilateral/contract/SearchIntTest.kt
+++ b/kotlin-client/src/integrationTest/kotlin/io/provenance/bilateral/contract/SearchIntTest.kt
@@ -51,9 +51,9 @@ class SearchIntTest : ContractIntTest() {
             gasAdjustment = 1.2,
         ).checkIsSuccess()
         val searchResult = bilateralClient.searchAsks(
-            ContractSearchRequest.newSearchAsks(
+            ContractSearchRequest(
                 searchType = ContractSearchType.byOwner(BilateralAccounts.askerAccount.address()),
-                pageSize = 11,
+                pageSize = 11.toBigInteger(),
             )
         )
         assertEquals(
@@ -121,9 +121,9 @@ class SearchIntTest : ContractIntTest() {
             gasAdjustment = 1.2,
         ).checkIsSuccess()
         val searchResult = bilateralClient.searchBids(
-            ContractSearchRequest.newSearchBids(
+            ContractSearchRequest(
                 searchType = ContractSearchType.byOwner(BilateralAccounts.bidderAccount.address()),
-                pageSize = 11,
+                pageSize = 11.toBigInteger(),
             )
         )
         assertEquals(

--- a/kotlin-client/src/integrationTest/kotlin/testconfiguration/testcontainers/ContractIntTest.kt
+++ b/kotlin-client/src/integrationTest/kotlin/testconfiguration/testcontainers/ContractIntTest.kt
@@ -1,6 +1,7 @@
 package testconfiguration.testcontainers
 
 import io.provenance.bilateral.client.BilateralContractClient
+import io.provenance.bilateral.client.BilateralContractClientLogger
 import io.provenance.bilateral.util.ContractAddressResolver
 import io.provenance.client.grpc.GasEstimationMethod
 import io.provenance.client.grpc.PbClient
@@ -37,10 +38,15 @@ abstract class ContractIntTest {
         lateinit var contractInfo: ContractInstantiationResult
 
         val bilateralClient by lazy {
-            BilateralContractClient.new(
+            BilateralContractClient.builder(
                 pbClient = pbClient,
                 addressResolver = ContractAddressResolver.ProvidedAddress(contractInfo.contractAddress)
-            )
+            ).setLogger(
+                BilateralContractClientLogger.Custom(
+                    infoLogger = { message -> logger.info(message) },
+                    errorLogger = { message, e -> logger.error(message, e) },
+                )
+            ).build()
         }
     }
 

--- a/kotlin-client/src/integrationTest/kotlin/testconfiguration/util/BilateralSmartContractUtil.kt
+++ b/kotlin-client/src/integrationTest/kotlin/testconfiguration/util/BilateralSmartContractUtil.kt
@@ -91,7 +91,9 @@ object BilateralSmartContractUtil {
 data class MetadataBilateralExchangeInstantiateMsg(
     val bindName: String,
     val contractName: String,
-) : ContractMsg
+) : ContractMsg {
+    override fun toLoggingString(): String = "metadataBilateralExchangeInstantiateMsg, bindName = [$bindName], contractName = [$contractName]"
+}
 
 data class ContractInstantiationResult(
     val codeId: Long,

--- a/kotlin-client/src/integrationTest/resources/data/provenance/config/config.toml
+++ b/kotlin-client/src/integrationTest/resources/data/provenance/config/config.toml
@@ -342,7 +342,7 @@ timeout_precommit_delta = "500ms"
 # How long we wait after committing a block, before starting on the new
 # height (this gives us a chance to receive some more precommits, even
 # though we already have +2/3).
-timeout_commit = "5s"
+timeout_commit = "100ms"
 
 # How many blocks to look back to check existence of the node's consensus votes before joining consensus
 # When non-zero, the node will panic upon restart

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/client/BilateralBroadcastOptions.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/client/BilateralBroadcastOptions.kt
@@ -3,7 +3,7 @@ package io.provenance.bilateral.client
 import cosmos.auth.v1beta1.Auth.BaseAccount
 import cosmos.tx.v1beta1.ServiceOuterClass.BroadcastMode
 
-data class BroadcastOptions(
+data class BilateralBroadcastOptions(
     val broadcastMode: BroadcastMode = BroadcastMode.BROADCAST_MODE_BLOCK,
     val sequenceOffset: Int = 0,
     val gasAdjustment: Double? = null,

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/client/BilateralContractClient.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/client/BilateralContractClient.kt
@@ -103,12 +103,26 @@ class BilateralContractClient private constructor(
         typeReference = object : TypeReference<ContractSearchResult<AskOrder>>() {},
     )
 
+    fun searchAsksOrNull(searchRequest: ContractSearchRequest): ContractSearchResult<AskOrder>? = queryContractOrNull(
+        query = searchRequest.searchAsks(),
+        typeReference = object : TypeReference<ContractSearchResult<AskOrder>>() {},
+    )
+
     fun searchBids(searchRequest: ContractSearchRequest): ContractSearchResult<BidOrder> = queryContract(
         query = searchRequest.searchBids(),
         typeReference = object : TypeReference<ContractSearchResult<BidOrder>>() {},
     )
 
+    fun searchBidsOrNull(searchRequest: ContractSearchRequest): ContractSearchResult<BidOrder>? = queryContractOrNull(
+        query = searchRequest.searchBids(),
+        typeReference = object : TypeReference<ContractSearchResult<BidOrder>>() {},
+    )
+
     fun getContractInfo(): ContractInfo = queryContract(
+        query = GetContractInfo(),
+    )
+
+    fun getContractInfoOrNull(): ContractInfo? = queryContract(
         query = GetContractInfo(),
     )
 

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/client/BilateralContractClient.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/client/BilateralContractClient.kt
@@ -68,57 +68,48 @@ class BilateralContractClient private constructor(
 
     fun getAsk(id: String): AskOrder = queryContract(
         query = GetAsk(id = id),
-        queryDescription = "getAsk, id = [$id]",
     )
 
     fun getAskOrNull(id: String): AskOrder? = queryContractOrNull(
         query = GetAsk(id = id),
-        queryDescription = "getAskOrNull, id = [$id]",
     )
 
     fun getAskByCollateralId(collateralId: String): AskOrder = queryContract(
         query = GetAskByCollateralId(collateralId = collateralId),
-        queryDescription = "getAskByCollateralId, collateralId = [$collateralId]",
     )
 
     fun getAskByCollateralIdOrNull(collateralId: String): AskOrder? = queryContractOrNull(
         query = GetAskByCollateralId(collateralId = collateralId),
-        queryDescription = "getAskByCollateralIdOrNull, collateralId = [$collateralId]",
     )
 
     fun getBid(id: String): BidOrder = queryContract(
         query = GetBid(id = id),
-        queryDescription = "getBid, id = [$id]",
     )
 
     fun getBidOrNull(id: String): BidOrder? = queryContractOrNull(
         query = GetBid(id = id),
-        queryDescription = "getBidOrNull, id = [$id]",
     )
 
     fun getMatchReport(askId: String, bidId: String): MatchReport = queryContract(
-        query = GetMatchReport(
-            askId = askId,
-            bidId = bidId,
-        ),
-        queryDescription = "getMatchReport, askId = [$askId], bidId = [$bidId]",
+        query = GetMatchReport(askId = askId, bidId = bidId),
+    )
+
+    fun getMatchReportOrNull(askId: String, bidId: String): MatchReport? = queryContractOrNull(
+        query = GetMatchReport(askId = askId, bidId = bidId),
     )
 
     fun searchAsks(searchRequest: ContractSearchRequest): ContractSearchResult<AskOrder> = queryContract(
         query = searchRequest.searchAsks(),
-        queryDescription = "searchAsks, ${searchRequest.getLoggingString()}",
         typeReference = object : TypeReference<ContractSearchResult<AskOrder>>() {},
     )
 
     fun searchBids(searchRequest: ContractSearchRequest): ContractSearchResult<BidOrder> = queryContract(
         query = searchRequest.searchBids(),
-        queryDescription = "searchBids, ${searchRequest.getLoggingString()}",
         typeReference = object : TypeReference<ContractSearchResult<BidOrder>>() {},
     )
 
     fun getContractInfo(): ContractInfo = queryContract(
         query = GetContractInfo(),
-        queryDescription = "getContractInfo",
     )
 
     fun createAsk(
@@ -130,7 +121,6 @@ class BilateralContractClient private constructor(
         signer = signer,
         options = options,
         funds = createAsk.getFunds(askFee = this.getContractInfo().askFee),
-        transactionDescription = createAsk.getLoggingString(),
     )
 
     fun createBid(
@@ -142,7 +132,6 @@ class BilateralContractClient private constructor(
         signer = signer,
         options = options,
         funds = createBid.getFunds(bidFee = this.getContractInfo().bidFee),
-        transactionDescription = createBid.getLoggingString(),
     )
 
     fun cancelAsk(
@@ -154,7 +143,6 @@ class BilateralContractClient private constructor(
         signer = signer,
         options = options,
         funds = emptyList(),
-        transactionDescription = "cancelAsk, askId = [$askId]",
     )
 
     fun cancelBid(
@@ -166,7 +154,6 @@ class BilateralContractClient private constructor(
         signer = signer,
         options = options,
         funds = emptyList(),
-        transactionDescription = "cancelBid, bidId = [$bidId]",
     )
 
     // IMPORTANT: The Signer used in this function must be the contract's admin account or the asker associated with the
@@ -180,7 +167,6 @@ class BilateralContractClient private constructor(
         signer = signer,
         options = options,
         funds = emptyList(),
-        transactionDescription = executeMatch.getLoggingString(),
     )
 
     // IMPORTANT: The Signer used in this function must be the contract's admin account.
@@ -193,7 +179,6 @@ class BilateralContractClient private constructor(
         signer = signer,
         options = options,
         funds = emptyList(),
-        transactionDescription = updateSettings.getLoggingString(),
     )
 
     fun generateCreateAskMsg(
@@ -203,7 +188,6 @@ class BilateralContractClient private constructor(
         executeMsg = createAsk,
         senderAddress = senderAddress,
         funds = createAsk.getFunds(askFee = this.getContractInfo().askFee),
-        transactionDescription = createAsk.getLoggingString(),
     )
 
     fun generateCreateBidMsg(
@@ -213,7 +197,6 @@ class BilateralContractClient private constructor(
         executeMsg = createBid,
         senderAddress = senderAddress,
         funds = createBid.getFunds(bidFee = this.getContractInfo().bidFee),
-        transactionDescription = createBid.getLoggingString(),
     )
 
     fun generateCancelAskMsg(
@@ -223,7 +206,6 @@ class BilateralContractClient private constructor(
         executeMsg = CancelAsk(askId),
         senderAddress = senderAddress,
         funds = emptyList(),
-        transactionDescription = "cancelAsk, askId = [$askId]",
     )
 
     fun generateCancelBidMsg(
@@ -233,7 +215,6 @@ class BilateralContractClient private constructor(
         executeMsg = CancelBid(bidId),
         senderAddress = senderAddress,
         funds = emptyList(),
-        transactionDescription = "cancelBid, bidId = [$bidId]",
     )
 
     // IMPORTANT: The Signer used in this function must be the contract's admin account or the asker associated with the
@@ -245,7 +226,6 @@ class BilateralContractClient private constructor(
         executeMsg = executeMatch,
         senderAddress = senderAddress,
         funds = emptyList(),
-        transactionDescription = executeMatch.getLoggingString(),
     )
 
     // IMPORTANT: The Signer used in this function must be the contract's admin account.
@@ -256,7 +236,6 @@ class BilateralContractClient private constructor(
         executeMsg = updateSettings,
         senderAddress = senderAddress,
         funds = emptyList(),
-        transactionDescription = updateSettings.getLoggingString(),
     )
 
     /**
@@ -266,9 +245,9 @@ class BilateralContractClient private constructor(
         executeMsg: ContractExecuteMsg,
         senderAddress: String,
         funds: List<Coin>,
-        transactionDescription: String,
         includeLogs: Boolean = true,
     ): MsgExecuteContract {
+        val transactionDescription = executeMsg.toLoggingString()
         if (includeLogs) {
             logger.info("START: Generating tx for $transactionDescription")
         }
@@ -293,14 +272,13 @@ class BilateralContractClient private constructor(
         signer: Signer,
         options: BilateralBroadcastOptions,
         funds: List<Coin>,
-        transactionDescription: String,
     ): BroadcastTxResponse {
+        val transactionDescription = executeMsg.toLoggingString()
         logger.info("START: $transactionDescription")
         val msg = generateProtoExecuteMsg(
             executeMsg = executeMsg,
             senderAddress = signer.address(),
             funds = funds,
-            transactionDescription = transactionDescription,
             includeLogs = false,
         )
         return pbClient.estimateAndBroadcastTx(
@@ -337,51 +315,48 @@ class BilateralContractClient private constructor(
      */
     private inline fun <T : ContractQueryMsg, reified U : Any> queryContractBase(
         query: T,
-        queryDescription: String,
         throwExceptions: Boolean,
         typeReference: TypeReference<U>?,
-    ): U? = try {
-        logger.info("START: $queryDescription")
-        val responseDataBytes = pbClient.wasmClient.queryWasm(
-            QueryOuterClass.QuerySmartContractStateRequest.newBuilder().also { req ->
-                req.address = contractAddress
-                req.queryData = query.toJsonByteString(objectMapper)
-            }.build()
-        ).data.toByteArray()
-        if (typeReference != null) {
-            objectMapper.readValue(responseDataBytes, typeReference)
-        } else {
-            objectMapper.readValue(responseDataBytes, U::class.java)
-        }.also {
-            logger.info("END: $queryDescription")
-        }
-    } catch (e: Exception) {
-        if (throwExceptions) {
-            throw e
-        } else {
-            logger.error("ERROR: $queryDescription", e)
-            null
+    ): U? = query.toLoggingString().let { queryDescription ->
+        try {
+            logger.info("START: $queryDescription")
+            val responseDataBytes = pbClient.wasmClient.queryWasm(
+                QueryOuterClass.QuerySmartContractStateRequest.newBuilder().also { req ->
+                    req.address = contractAddress
+                    req.queryData = query.toJsonByteString(objectMapper)
+                }.build()
+            ).data.toByteArray()
+            if (typeReference != null) {
+                objectMapper.readValue(responseDataBytes, typeReference)
+            } else {
+                objectMapper.readValue(responseDataBytes, U::class.java)
+            }.also {
+                logger.info("END: $queryDescription")
+            }
+        } catch (e: Exception) {
+            if (throwExceptions) {
+                throw e
+            } else {
+                logger.error("ERROR: $queryDescription", e)
+                null
+            }
         }
     }
 
     private inline fun <T : ContractQueryMsg, reified U : Any> queryContractOrNull(
         query: T,
-        queryDescription: String,
         typeReference: TypeReference<U>? = null,
     ): U? = queryContractBase(
         query = query,
-        queryDescription = queryDescription,
         throwExceptions = false,
         typeReference = typeReference,
     )
 
     private inline fun <T : ContractQueryMsg, reified U : Any> queryContract(
         query: T,
-        queryDescription: String,
         typeReference: TypeReference<U>? = null,
     ): U = queryContractBase(
         query = query,
-        queryDescription = queryDescription,
         throwExceptions = true,
         typeReference = typeReference,
     ) ?: throw NullContractResultException("Got null response from the Metadata Bilateral Exchange contract for query")

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/client/BilateralContractClient.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/client/BilateralContractClient.kt
@@ -335,7 +335,7 @@ class BilateralContractClient private constructor(
      * types that include lists of values or other generic parameters need this instead of a class reference for proper
      * deserialization inference.
      */
-    private inline fun <T : ContractQueryMsg, reified U : Any> queryContractInternal(
+    private inline fun <T : ContractQueryMsg, reified U : Any> queryContractBase(
         query: T,
         queryDescription: String,
         throwExceptions: Boolean,
@@ -368,7 +368,7 @@ class BilateralContractClient private constructor(
         query: T,
         queryDescription: String,
         typeReference: TypeReference<U>? = null,
-    ): U? = queryContractInternal(
+    ): U? = queryContractBase(
         query = query,
         queryDescription = queryDescription,
         throwExceptions = false,
@@ -379,7 +379,7 @@ class BilateralContractClient private constructor(
         query: T,
         queryDescription: String,
         typeReference: TypeReference<U>? = null,
-    ): U = queryContractInternal(
+    ): U = queryContractBase(
         query = query,
         queryDescription = queryDescription,
         throwExceptions = true,

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/client/BilateralContractClient.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/client/BilateralContractClient.kt
@@ -6,27 +6,26 @@ import cosmos.base.v1beta1.CoinOuterClass.Coin
 import cosmos.tx.v1beta1.ServiceOuterClass.BroadcastTxResponse
 import cosmwasm.wasm.v1.QueryOuterClass
 import cosmwasm.wasm.v1.Tx.MsgExecuteContract
+import io.provenance.bilateral.exceptions.NullContractResultException
 import io.provenance.bilateral.execute.CancelAsk
 import io.provenance.bilateral.execute.CancelBid
 import io.provenance.bilateral.execute.CreateAsk
 import io.provenance.bilateral.execute.CreateBid
 import io.provenance.bilateral.execute.ExecuteMatch
 import io.provenance.bilateral.execute.UpdateSettings
-import io.provenance.bilateral.functions.tryOrNull
 import io.provenance.bilateral.interfaces.ContractExecuteMsg
 import io.provenance.bilateral.interfaces.ContractQueryMsg
 import io.provenance.bilateral.models.AskOrder
 import io.provenance.bilateral.models.BidOrder
 import io.provenance.bilateral.models.ContractInfo
 import io.provenance.bilateral.models.MatchReport
+import io.provenance.bilateral.query.ContractSearchRequest
 import io.provenance.bilateral.query.ContractSearchResult
 import io.provenance.bilateral.query.GetAsk
 import io.provenance.bilateral.query.GetAskByCollateralId
 import io.provenance.bilateral.query.GetBid
 import io.provenance.bilateral.query.GetContractInfo
 import io.provenance.bilateral.query.GetMatchReport
-import io.provenance.bilateral.query.SearchAsks
-import io.provenance.bilateral.query.SearchBids
 import io.provenance.bilateral.util.ContractAddressResolver
 import io.provenance.bilateral.util.ObjectMapperProvider
 import io.provenance.client.grpc.BaseReqSigner
@@ -55,39 +54,40 @@ class BilateralContractClient private constructor(
 
     val contractAddress by lazy { addressResolver.getAddress(pbClient) }
 
-    fun getAsk(id: String): AskOrder = queryContract(GetAsk(id))
+    fun getAsk(id: String): AskOrder = queryContract(query = GetAsk(id = id))
 
-    fun getAskOrNull(id: String): AskOrder? = tryOrNull { getAsk(id) }
+    fun getAskOrNull(id: String): AskOrder? = queryContractOrNull(query = GetAsk(id = id))
 
-    fun getAskByCollateralId(collateralId: String): AskOrder = queryContract(GetAskByCollateralId(collateralId))
+    fun getAskByCollateralId(collateralId: String): AskOrder = queryContract(
+        query = GetAskByCollateralId(collateralId = collateralId),
+    )
 
-    fun getAskByCollateralIdOrNull(collateralId: String): AskOrder? = tryOrNull { getAskByCollateralId(collateralId) }
+    fun getAskByCollateralIdOrNull(collateralId: String): AskOrder? = queryContractOrNull(
+        query = GetAskByCollateralId(collateralId = collateralId),
+    )
 
-    fun getBid(id: String): BidOrder = queryContract(GetBid(id))
+    fun getBid(id: String): BidOrder = queryContract(query = GetBid(id = id))
 
-    fun getBidOrNull(id: String): BidOrder? = tryOrNull { getBid(id) }
+    fun getBidOrNull(id: String): BidOrder? = queryContractOrNull(query = GetBid(id = id))
 
-    fun getMatchReport(askId: String, bidId: String): MatchReport = queryContract(GetMatchReport(askId, bidId))
+    fun getMatchReport(askId: String, bidId: String): MatchReport = queryContract(
+        query = GetMatchReport(
+            askId = askId,
+            bidId = bidId,
+        ),
+    )
 
-    fun getMatchReportOrNull(askId: String, bidId: String): MatchReport? = tryOrNull { getMatchReport(askId, bidId) }
-
-    fun searchAsks(searchAsks: SearchAsks): ContractSearchResult<AskOrder> = queryContractWithReference(
-        query = searchAsks,
+    fun searchAsks(searchRequest: ContractSearchRequest): ContractSearchResult<AskOrder> = queryContractWithReference(
+        query = searchRequest.searchAsks(),
         typeReference = object : TypeReference<ContractSearchResult<AskOrder>>() {},
     )
 
-    fun searchAsksOrNull(searchAsks: SearchAsks): ContractSearchResult<AskOrder>? = tryOrNull { searchAsks(searchAsks) }
-
-    fun searchBids(searchBids: SearchBids): ContractSearchResult<BidOrder> = queryContractWithReference(
-        query = searchBids,
+    fun searchBids(searchRequest: ContractSearchRequest): ContractSearchResult<BidOrder> = queryContractWithReference(
+        query = searchRequest.searchBids(),
         typeReference = object : TypeReference<ContractSearchResult<BidOrder>>() {},
     )
 
-    fun searchBidsOrNull(searchBids: SearchBids): ContractSearchResult<BidOrder>? = tryOrNull { searchBids(searchBids) }
-
-    fun getContractInfo(): ContractInfo = queryContract(GetContractInfo())
-
-    fun getContractInfoOrNull(): ContractInfo? = tryOrNull { getContractInfo() }
+    fun getContractInfo(): ContractInfo = queryContract(query = GetContractInfo())
 
     fun createAsk(
         createAsk: CreateAsk,
@@ -265,8 +265,11 @@ class BilateralContractClient private constructor(
         }.build()
     ).data.toByteArray()
 
-    private inline fun <T : ContractQueryMsg, reified U : Any> queryContract(query: T): U =
+    private inline fun <T: ContractQueryMsg, reified U: Any> queryContractOrNull(query: T): U? =
         getQueryResponseBytes(query).let { bytes -> objectMapper.readValue(bytes, U::class.java) }
+
+    private inline fun <T : ContractQueryMsg, reified U : Any> queryContract(query: T): U =
+        queryContractOrNull(query) ?: throw NullContractResultException("Got null response from the Metadata Bilateral Exchange contract for query")
 
     /**
      * Allows a type reference to be passed in, ensuring that generic types within response values can be properly

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/client/BilateralContractClientLogger.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/client/BilateralContractClientLogger.kt
@@ -1,0 +1,29 @@
+package io.provenance.bilateral.client
+
+sealed interface BilateralContractClientLogger {
+    fun info(message: String)
+    fun error(message: String, e: Exception?)
+
+    object Off : BilateralContractClientLogger {
+        override fun info(message: String) {}
+        override fun error(message: String, e: Exception?) {}
+    }
+
+    object Println : BilateralContractClientLogger {
+        override fun info(message: String) {
+            println(message)
+        }
+
+        override fun error(message: String, e: Exception?) {
+            System.err.println("$message${e?.let { exception -> ": ${exception.message}"} ?: ""}")
+        }
+    }
+
+    class Custom(
+        private val infoLogger: (message: String) -> Unit,
+        private val errorLogger: (message: String, e: Exception?) -> Unit,
+    ) : BilateralContractClientLogger {
+        override fun info(message: String) = infoLogger.invoke(message)
+        override fun error(message: String, e: Exception?) = errorLogger.invoke(message, e)
+    }
+}

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/exceptions/NullContractResultException.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/exceptions/NullContractResultException.kt
@@ -1,0 +1,3 @@
+package io.provenance.bilateral.exceptions
+
+class NullContractResultException(message: String, e: Exception? = null) : Exception(message, e)

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/execute/CancelAsk.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/execute/CancelAsk.kt
@@ -9,4 +9,6 @@ import io.provenance.bilateral.interfaces.ContractExecuteMsg
 @JsonNaming(SnakeCaseStrategy::class)
 @JsonTypeInfo(include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.NAME)
 @JsonTypeName("cancel_ask")
-data class CancelAsk(val id: String) : ContractExecuteMsg
+data class CancelAsk(val id: String) : ContractExecuteMsg {
+    override fun toLoggingString(): String = "cancelAsk, id = [$id]"
+}

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/execute/CancelBid.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/execute/CancelBid.kt
@@ -9,4 +9,6 @@ import io.provenance.bilateral.interfaces.ContractExecuteMsg
 @JsonNaming(SnakeCaseStrategy::class)
 @JsonTypeInfo(include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.NAME)
 @JsonTypeName("cancel_bid")
-data class CancelBid(val id: String) : ContractExecuteMsg
+data class CancelBid(val id: String) : ContractExecuteMsg {
+    override fun toLoggingString(): String = "cancelBid, id = [$id]"
+}

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/execute/CreateAsk.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/execute/CreateAsk.kt
@@ -115,6 +115,14 @@ data class CreateAsk(
     ).let { funds ->
         askFee?.let { CoinUtil.combineFunds(funds, it) } ?: funds
     }
+
+    @JsonIgnore
+    internal fun getLoggingString(): String = mapAsk(
+        coinTrade = { "askType = [coin_trade], id = [${it.id}]" },
+        markerTrade = { "askType = [marker_trade], id = [${it.id}], markerDenom = [${it.markerDenom}]" },
+        markerShareSale = { "askType = [marker_share_sale], id = [${it.id}], markerDenom = [${it.markerDenom}], sharesToSell = [${it.sharesToSell}]" },
+        scopeTrade = { "askType = [scope_trade], id = [${it.id}], scopeAddress = [${it.scopeAddress}]" },
+    ).let { suffix -> "createAsk, $suffix" }
 }
 
 @JsonTypeInfo(include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.NAME)

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/execute/CreateAsk.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/execute/CreateAsk.kt
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.annotation.JsonTypeName
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.annotation.JsonNaming
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import cosmos.base.v1beta1.CoinOuterClass.Coin
 import io.provenance.bilateral.execute.Ask.CoinTradeAsk
 import io.provenance.bilateral.execute.Ask.MarkerShareSaleAsk
@@ -13,7 +15,10 @@ import io.provenance.bilateral.execute.Ask.ScopeTradeAsk
 import io.provenance.bilateral.interfaces.ContractExecuteMsg
 import io.provenance.bilateral.models.RequestDescriptor
 import io.provenance.bilateral.models.ShareSaleType
+import io.provenance.bilateral.serialization.CosmWasmBigIntegerToUintSerializer
+import io.provenance.bilateral.serialization.CosmWasmUintToBigIntegerDeserializer
 import io.provenance.bilateral.util.CoinUtil
+import java.math.BigInteger
 
 @JsonNaming(SnakeCaseStrategy::class)
 @JsonTypeInfo(include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.NAME)
@@ -58,7 +63,7 @@ data class CreateAsk(
         fun newMarkerShareSale(
             id: String,
             markerDenom: String,
-            sharesToSell: String,
+            sharesToSell: BigInteger,
             quotePerShare: List<Coin>,
             shareSaleType: ShareSaleType,
             descriptor: RequestDescriptor? = null,
@@ -139,7 +144,9 @@ sealed interface Ask {
     data class MarkerShareSaleAsk(
         val id: String,
         val markerDenom: String,
-        val sharesToSell: String,
+        @JsonSerialize(using = CosmWasmBigIntegerToUintSerializer::class)
+        @JsonDeserialize(using = CosmWasmUintToBigIntegerDeserializer::class)
+        val sharesToSell: BigInteger,
         val quotePerShare: List<Coin>,
         val shareSaleType: ShareSaleType,
     ) : Ask

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/execute/CreateAsk.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/execute/CreateAsk.kt
@@ -116,8 +116,7 @@ data class CreateAsk(
         askFee?.let { CoinUtil.combineFunds(funds, it) } ?: funds
     }
 
-    @JsonIgnore
-    internal fun getLoggingString(): String = mapAsk(
+    override fun toLoggingString(): String = mapAsk(
         coinTrade = { "askType = [coin_trade], id = [${it.id}]" },
         markerTrade = { "askType = [marker_trade], id = [${it.id}], markerDenom = [${it.markerDenom}]" },
         markerShareSale = { "askType = [marker_share_sale], id = [${it.id}], markerDenom = [${it.markerDenom}], sharesToSell = [${it.sharesToSell}]" },

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/execute/CreateAsk.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/execute/CreateAsk.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.annotation.JsonTypeName
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.annotation.JsonNaming
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import cosmos.base.v1beta1.CoinOuterClass.Coin
@@ -16,7 +15,6 @@ import io.provenance.bilateral.interfaces.ContractExecuteMsg
 import io.provenance.bilateral.models.RequestDescriptor
 import io.provenance.bilateral.models.ShareSaleType
 import io.provenance.bilateral.serialization.CosmWasmBigIntegerToUintSerializer
-import io.provenance.bilateral.serialization.CosmWasmUintToBigIntegerDeserializer
 import io.provenance.bilateral.util.CoinUtil
 import java.math.BigInteger
 
@@ -145,7 +143,6 @@ sealed interface Ask {
         val id: String,
         val markerDenom: String,
         @JsonSerialize(using = CosmWasmBigIntegerToUintSerializer::class)
-        @JsonDeserialize(using = CosmWasmUintToBigIntegerDeserializer::class)
         val sharesToSell: BigInteger,
         val quotePerShare: List<Coin>,
         val shareSaleType: ShareSaleType,

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/execute/CreateBid.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/execute/CreateBid.kt
@@ -111,6 +111,14 @@ data class CreateBid(val bid: Bid, val descriptor: RequestDescriptor?) : Contrac
     ).let { funds ->
         bidFee?.let { CoinUtil.combineFunds(funds, bidFee) } ?: funds
     }
+
+    @JsonIgnore
+    internal fun getLoggingString(): String = mapBid(
+        coinTrade = { "bidType = [coin_trade], id = [${it.id}]" },
+        markerTrade = { "bidType = [marker_trade], id = [${it.id}], markerDenom = [${it.markerDenom}]" },
+        markerShareSale = { "bidType = [marker_share_sale], id = [${it.id}], markerDenom = [${it.markerDenom}], shareCount = [${it.shareCount}]" },
+        scopeTrade = { "bidType = [scope_trade], id = [${it.id}], scopeAddress = [${it.scopeAddress}]" },
+    ).let { suffix -> "createBid, $suffix" }
 }
 
 @JsonTypeInfo(include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.NAME)

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/execute/CreateBid.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/execute/CreateBid.kt
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.annotation.JsonTypeName
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.annotation.JsonNaming
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import cosmos.base.v1beta1.CoinOuterClass.Coin
 import io.provenance.bilateral.execute.Bid.CoinTradeBid
 import io.provenance.bilateral.execute.Bid.MarkerShareSaleBid
@@ -12,7 +14,10 @@ import io.provenance.bilateral.execute.Bid.MarkerTradeBid
 import io.provenance.bilateral.execute.Bid.ScopeTradeBid
 import io.provenance.bilateral.interfaces.ContractExecuteMsg
 import io.provenance.bilateral.models.RequestDescriptor
+import io.provenance.bilateral.serialization.CosmWasmBigIntegerToUintSerializer
+import io.provenance.bilateral.serialization.CosmWasmUintToBigIntegerDeserializer
 import io.provenance.bilateral.util.CoinUtil
+import java.math.BigInteger
 
 @JsonNaming(SnakeCaseStrategy::class)
 @JsonTypeInfo(include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.NAME)
@@ -50,7 +55,7 @@ data class CreateBid(val bid: Bid, val descriptor: RequestDescriptor?) : Contrac
         fun newMarkerShareSale(
             id: String,
             markerDenom: String,
-            shareCount: String,
+            shareCount: BigInteger,
             quote: List<Coin>,
             descriptor: RequestDescriptor? = null,
         ): CreateBid = CreateBid(
@@ -137,7 +142,9 @@ sealed interface Bid {
     data class MarkerShareSaleBid(
         val id: String,
         val markerDenom: String,
-        val shareCount: String,
+        @JsonSerialize(using = CosmWasmBigIntegerToUintSerializer::class)
+        @JsonDeserialize(using = CosmWasmUintToBigIntegerDeserializer::class)
+        val shareCount: BigInteger,
         // The quote is used for funds, and never added to the json payload send to the contract
         @JsonIgnore
         val quote: List<Coin>,

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/execute/CreateBid.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/execute/CreateBid.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.annotation.JsonTypeName
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.annotation.JsonNaming
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import cosmos.base.v1beta1.CoinOuterClass.Coin
@@ -15,7 +14,6 @@ import io.provenance.bilateral.execute.Bid.ScopeTradeBid
 import io.provenance.bilateral.interfaces.ContractExecuteMsg
 import io.provenance.bilateral.models.RequestDescriptor
 import io.provenance.bilateral.serialization.CosmWasmBigIntegerToUintSerializer
-import io.provenance.bilateral.serialization.CosmWasmUintToBigIntegerDeserializer
 import io.provenance.bilateral.util.CoinUtil
 import java.math.BigInteger
 
@@ -143,7 +141,6 @@ sealed interface Bid {
         val id: String,
         val markerDenom: String,
         @JsonSerialize(using = CosmWasmBigIntegerToUintSerializer::class)
-        @JsonDeserialize(using = CosmWasmUintToBigIntegerDeserializer::class)
         val shareCount: BigInteger,
         // The quote is used for funds, and never added to the json payload send to the contract
         @JsonIgnore

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/execute/CreateBid.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/execute/CreateBid.kt
@@ -112,8 +112,7 @@ data class CreateBid(val bid: Bid, val descriptor: RequestDescriptor?) : Contrac
         bidFee?.let { CoinUtil.combineFunds(funds, bidFee) } ?: funds
     }
 
-    @JsonIgnore
-    internal fun getLoggingString(): String = mapBid(
+    override fun toLoggingString(): String = mapBid(
         coinTrade = { "bidType = [coin_trade], id = [${it.id}]" },
         markerTrade = { "bidType = [marker_trade], id = [${it.id}], markerDenom = [${it.markerDenom}]" },
         markerShareSale = { "bidType = [marker_share_sale], id = [${it.id}], markerDenom = [${it.markerDenom}], shareCount = [${it.shareCount}]" },

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/execute/ExecuteMatch.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/execute/ExecuteMatch.kt
@@ -1,6 +1,5 @@
 package io.provenance.bilateral.execute
 
-import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.annotation.JsonTypeName
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/execute/ExecuteMatch.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/execute/ExecuteMatch.kt
@@ -1,5 +1,6 @@
 package io.provenance.bilateral.execute
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.annotation.JsonTypeName
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy
@@ -23,4 +24,7 @@ data class ExecuteMatch(
     val askId: String,
     val bidId: String,
     val acceptMismatchedBids: Boolean? = null,
-) : ContractExecuteMsg
+) : ContractExecuteMsg {
+    @JsonIgnore
+    internal fun getLoggingString(): String = "executeMatch, askId = [$askId], bidId = [$bidId], acceptMismatchedBids = [$acceptMismatchedBids]"
+}

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/execute/ExecuteMatch.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/execute/ExecuteMatch.kt
@@ -25,6 +25,5 @@ data class ExecuteMatch(
     val bidId: String,
     val acceptMismatchedBids: Boolean? = null,
 ) : ContractExecuteMsg {
-    @JsonIgnore
-    internal fun getLoggingString(): String = "executeMatch, askId = [$askId], bidId = [$bidId], acceptMismatchedBids = [$acceptMismatchedBids]"
+    override fun toLoggingString(): String = "executeMatch, askId = [$askId], bidId = [$bidId], acceptMismatchedBids = [$acceptMismatchedBids]"
 }

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/execute/UpdateSettings.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/execute/UpdateSettings.kt
@@ -1,6 +1,5 @@
 package io.provenance.bilateral.execute
 
-import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.annotation.JsonTypeName
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy
@@ -37,8 +36,7 @@ data class UpdateSettings(val update: Body) : ContractExecuteMsg {
         )
     }
 
-    @JsonIgnore
-    fun getLoggingString(): String = "updateSettings, " +
+    override fun toLoggingString(): String = "updateSettings, " +
         "newAdminAddress = [${update.newAdminAddress}], " +
         "askFee = [${update.askFee?.let { "new value" } ?: "cleared"}], " +
         "bidFee = [${update.bidFee?.let { "new value" } ?: "cleared"}]"

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/execute/UpdateSettings.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/execute/UpdateSettings.kt
@@ -1,5 +1,6 @@
 package io.provenance.bilateral.execute
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.annotation.JsonTypeName
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy
@@ -35,4 +36,10 @@ data class UpdateSettings(val update: Body) : ContractExecuteMsg {
             update = Body(newAdminAddress, askFee, bidFee),
         )
     }
+
+    @JsonIgnore
+    fun getLoggingString(): String = "updateSettings, " +
+        "newAdminAddress = [${update.newAdminAddress}], " +
+        "askFee = [${update.askFee?.let { "new value" } ?: "cleared"}], " +
+        "bidFee = [${update.bidFee?.let { "new value" } ?: "cleared"}]"
 }

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/functions/GenericFunctions.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/functions/GenericFunctions.kt
@@ -1,7 +1,0 @@
-package io.provenance.bilateral.functions
-
-internal fun <T> tryOrNull(fn: () -> T): T? = try {
-    fn()
-} catch (e: Exception) {
-    null
-}

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/interfaces/ContractMsg.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/interfaces/ContractMsg.kt
@@ -5,5 +5,7 @@ import com.google.protobuf.ByteString
 import io.provenance.scope.util.toByteString
 
 interface ContractMsg {
+    fun toLoggingString(): String
+
     fun toJsonByteString(objectMapper: ObjectMapper): ByteString = objectMapper.writeValueAsString(this).toByteString()
 }

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/models/AskOrder.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/models/AskOrder.kt
@@ -4,12 +4,17 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.annotation.JsonTypeName
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.annotation.JsonNaming
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import cosmos.base.v1beta1.CoinOuterClass.Coin
 import io.provenance.bilateral.models.AskCollateral.CoinTrade
 import io.provenance.bilateral.models.AskCollateral.MarkerShareSale
 import io.provenance.bilateral.models.AskCollateral.MarkerTrade
 import io.provenance.bilateral.models.AskCollateral.ScopeTrade
+import io.provenance.bilateral.serialization.CosmWasmBigIntegerToUintSerializer
+import io.provenance.bilateral.serialization.CosmWasmUintToBigIntegerDeserializer
+import java.math.BigInteger
 
 @JsonNaming(SnakeCaseStrategy::class)
 data class AskOrder(
@@ -56,8 +61,12 @@ sealed interface AskCollateral {
     data class MarkerShareSale(
         val markerAddress: String,
         val markerDenom: String,
-        val totalSharesInSale: String,
-        val remainingSharesInSale: String,
+        @JsonSerialize(using = CosmWasmBigIntegerToUintSerializer::class)
+        @JsonDeserialize(using = CosmWasmUintToBigIntegerDeserializer::class)
+        val totalSharesInSale: BigInteger,
+        @JsonSerialize(using = CosmWasmBigIntegerToUintSerializer::class)
+        @JsonDeserialize(using = CosmWasmUintToBigIntegerDeserializer::class)
+        val remainingSharesInSale: BigInteger,
         val quotePerShare: List<Coin>,
         val removedPermissions: List<MarkerAccessGrant>,
         val saleType: ShareSaleType,

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/models/AskOrder.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/models/AskOrder.kt
@@ -6,13 +6,11 @@ import com.fasterxml.jackson.annotation.JsonTypeName
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.annotation.JsonNaming
-import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import cosmos.base.v1beta1.CoinOuterClass.Coin
 import io.provenance.bilateral.models.AskCollateral.CoinTrade
 import io.provenance.bilateral.models.AskCollateral.MarkerShareSale
 import io.provenance.bilateral.models.AskCollateral.MarkerTrade
 import io.provenance.bilateral.models.AskCollateral.ScopeTrade
-import io.provenance.bilateral.serialization.CosmWasmBigIntegerToUintSerializer
 import io.provenance.bilateral.serialization.CosmWasmUintToBigIntegerDeserializer
 import java.math.BigInteger
 
@@ -61,10 +59,8 @@ sealed interface AskCollateral {
     data class MarkerShareSale(
         val markerAddress: String,
         val markerDenom: String,
-        @JsonSerialize(using = CosmWasmBigIntegerToUintSerializer::class)
         @JsonDeserialize(using = CosmWasmUintToBigIntegerDeserializer::class)
         val totalSharesInSale: BigInteger,
-        @JsonSerialize(using = CosmWasmBigIntegerToUintSerializer::class)
         @JsonDeserialize(using = CosmWasmUintToBigIntegerDeserializer::class)
         val remainingSharesInSale: BigInteger,
         val quotePerShare: List<Coin>,

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/models/BidOrder.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/models/BidOrder.kt
@@ -4,12 +4,17 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.annotation.JsonTypeName
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.annotation.JsonNaming
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import cosmos.base.v1beta1.CoinOuterClass.Coin
 import io.provenance.bilateral.models.BidCollateral.CoinTrade
 import io.provenance.bilateral.models.BidCollateral.MarkerShareSale
 import io.provenance.bilateral.models.BidCollateral.MarkerTrade
 import io.provenance.bilateral.models.BidCollateral.ScopeTrade
+import io.provenance.bilateral.serialization.CosmWasmBigIntegerToUintSerializer
+import io.provenance.bilateral.serialization.CosmWasmUintToBigIntegerDeserializer
+import java.math.BigInteger
 
 @JsonNaming(SnakeCaseStrategy::class)
 data class BidOrder(
@@ -55,7 +60,9 @@ sealed interface BidCollateral {
     data class MarkerShareSale(
         val markerAddress: String,
         val markerDenom: String,
-        val shareCount: String,
+        @JsonSerialize(using = CosmWasmBigIntegerToUintSerializer::class)
+        @JsonDeserialize(using = CosmWasmUintToBigIntegerDeserializer::class)
+        val shareCount: BigInteger,
         val quote: List<Coin>,
     ) : BidCollateral
 

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/models/BidOrder.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/models/BidOrder.kt
@@ -6,13 +6,11 @@ import com.fasterxml.jackson.annotation.JsonTypeName
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.annotation.JsonNaming
-import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import cosmos.base.v1beta1.CoinOuterClass.Coin
 import io.provenance.bilateral.models.BidCollateral.CoinTrade
 import io.provenance.bilateral.models.BidCollateral.MarkerShareSale
 import io.provenance.bilateral.models.BidCollateral.MarkerTrade
 import io.provenance.bilateral.models.BidCollateral.ScopeTrade
-import io.provenance.bilateral.serialization.CosmWasmBigIntegerToUintSerializer
 import io.provenance.bilateral.serialization.CosmWasmUintToBigIntegerDeserializer
 import java.math.BigInteger
 
@@ -60,7 +58,6 @@ sealed interface BidCollateral {
     data class MarkerShareSale(
         val markerAddress: String,
         val markerDenom: String,
-        @JsonSerialize(using = CosmWasmBigIntegerToUintSerializer::class)
         @JsonDeserialize(using = CosmWasmUintToBigIntegerDeserializer::class)
         val shareCount: BigInteger,
         val quote: List<Coin>,

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/models/RequestDescriptor.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/models/RequestDescriptor.kt
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.annotation.JsonNaming
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
-import io.provenance.bilateral.serialization.CosmWasmUTCTimestampToOffsetDateTimeDeserializer
 import io.provenance.bilateral.serialization.CosmWasmUTCOffsetDateTimeToTimestampSerializer
+import io.provenance.bilateral.serialization.CosmWasmUTCTimestampToOffsetDateTimeDeserializer
 import java.time.OffsetDateTime
 
 /**

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/models/RequestDescriptor.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/models/RequestDescriptor.kt
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.annotation.JsonNaming
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
-import io.provenance.bilateral.serialization.ContractUTCTimestampDeserializer
-import io.provenance.bilateral.serialization.ContractUTCTimestampSerializer
+import io.provenance.bilateral.serialization.CosmWasmUTCTimestampToOffsetDateTimeDeserializer
+import io.provenance.bilateral.serialization.CosmWasmUTCOffsetDateTimeToTimestampSerializer
 import java.time.OffsetDateTime
 
 /**
@@ -17,8 +17,8 @@ import java.time.OffsetDateTime
 @JsonNaming(SnakeCaseStrategy::class)
 data class RequestDescriptor(
     val description: String? = null,
-    @JsonSerialize(using = ContractUTCTimestampSerializer::class)
-    @JsonDeserialize(using = ContractUTCTimestampDeserializer::class)
+    @JsonSerialize(using = CosmWasmUTCOffsetDateTimeToTimestampSerializer::class)
+    @JsonDeserialize(using = CosmWasmUTCTimestampToOffsetDateTimeDeserializer::class)
     val effectiveTime: OffsetDateTime? = null,
     val attributeRequirement: AttributeRequirement? = null,
 )

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/query/GetAsk.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/query/GetAsk.kt
@@ -9,4 +9,6 @@ import io.provenance.bilateral.interfaces.ContractQueryMsg
 @JsonNaming(SnakeCaseStrategy::class)
 @JsonTypeInfo(include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.NAME)
 @JsonTypeName("get_ask")
-data class GetAsk(val id: String) : ContractQueryMsg
+data class GetAsk(val id: String) : ContractQueryMsg {
+    override fun toLoggingString(): String = "getAsk, id = [$id]"
+}

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/query/GetAskByCollateralId.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/query/GetAskByCollateralId.kt
@@ -16,4 +16,6 @@ import io.provenance.bilateral.interfaces.ContractQueryMsg
 @JsonNaming(SnakeCaseStrategy::class)
 @JsonTypeInfo(include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.NAME)
 @JsonTypeName("get_ask_by_collateral_id")
-data class GetAskByCollateralId(val collateralId: String) : ContractQueryMsg
+data class GetAskByCollateralId(val collateralId: String) : ContractQueryMsg {
+    override fun toLoggingString(): String = "getAskByCollateralId, collateralId = [$collateralId]"
+}

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/query/GetBid.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/query/GetBid.kt
@@ -9,4 +9,6 @@ import io.provenance.bilateral.interfaces.ContractQueryMsg
 @JsonNaming(SnakeCaseStrategy::class)
 @JsonTypeInfo(include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.NAME)
 @JsonTypeName("get_bid")
-data class GetBid(val id: String) : ContractQueryMsg
+data class GetBid(val id: String) : ContractQueryMsg {
+    override fun toLoggingString(): String = "getBid, id = [$id]"
+}

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/query/GetContractInfo.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/query/GetContractInfo.kt
@@ -9,4 +9,6 @@ import io.provenance.bilateral.interfaces.ContractQueryMsg
 @JsonNaming(SnakeCaseStrategy::class)
 @JsonTypeInfo(include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.NAME)
 @JsonTypeName("get_contract_info")
-class GetContractInfo : ContractQueryMsg
+class GetContractInfo : ContractQueryMsg {
+    override fun toLoggingString(): String = "getContractInfo"
+}

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/query/GetMatchReport.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/query/GetMatchReport.kt
@@ -9,4 +9,6 @@ import io.provenance.bilateral.interfaces.ContractQueryMsg
 @JsonNaming(SnakeCaseStrategy::class)
 @JsonTypeInfo(include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.NAME)
 @JsonTypeName("get_match_report")
-data class GetMatchReport(val askId: String, val bidId: String) : ContractQueryMsg
+data class GetMatchReport(val askId: String, val bidId: String) : ContractQueryMsg {
+    override fun toLoggingString(): String = "getMatchReport, askId = [$askId], bidId = [$bidId]"
+}

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/query/SearchContract.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/query/SearchContract.kt
@@ -1,5 +1,6 @@
 package io.provenance.bilateral.query
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.annotation.JsonTypeName
 import com.fasterxml.jackson.annotation.JsonValue
@@ -36,6 +37,14 @@ data class ContractSearchRequest(
 ) {
     internal fun searchAsks(): SearchAsks = SearchAsks(this)
     internal fun searchBids(): SearchBids = SearchBids(this)
+
+    @JsonIgnore
+    internal fun getLoggingString(): String = when (this.searchType) {
+        is ContractSearchType.All -> "[all]"
+        is ContractSearchType.Type -> "[type], type = [${this.searchType.valueType}]"
+        is ContractSearchType.Id -> "[id], id = [${this.searchType.id}]"
+        is ContractSearchType.Owner -> "[owner], owner = [${this.searchType.owner}]"
+    }.let { searchTypeString -> "searchType = $searchTypeString, pageSize = [${pageSize ?: "DEFAULT"}, pageNumber = [${pageNumber ?: "DEFAULT"}]" }
 }
 
 sealed interface ContractSearchType {

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/query/SearchContract.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/query/SearchContract.kt
@@ -17,7 +17,9 @@ import java.math.BigInteger
 @JsonNaming(SnakeCaseStrategy::class)
 @JsonTypeInfo(include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.NAME)
 @JsonTypeName("search_asks")
-data class SearchAsks(val search: ContractSearchRequest) : ContractQueryMsg
+data class SearchAsks(val search: ContractSearchRequest) : ContractQueryMsg {
+    override fun toLoggingString(): String = "searchAsks, ${search.getLoggingSuffix()}"
+}
 
 /**
  * See ContractSearchType for JSON payloads for each different type of bid search.
@@ -25,7 +27,9 @@ data class SearchAsks(val search: ContractSearchRequest) : ContractQueryMsg
 @JsonNaming(SnakeCaseStrategy::class)
 @JsonTypeInfo(include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.NAME)
 @JsonTypeName("search_bids")
-data class SearchBids(val search: ContractSearchRequest) : ContractQueryMsg
+data class SearchBids(val search: ContractSearchRequest) : ContractQueryMsg {
+    override fun toLoggingString(): String = "searchBids, ${search.getLoggingSuffix()}"
+}
 
 @JsonNaming(SnakeCaseStrategy::class)
 data class ContractSearchRequest(
@@ -39,7 +43,7 @@ data class ContractSearchRequest(
     internal fun searchBids(): SearchBids = SearchBids(this)
 
     @JsonIgnore
-    internal fun getLoggingString(): String = when (this.searchType) {
+    internal fun getLoggingSuffix(): String = when (this.searchType) {
         is ContractSearchType.All -> "[all]"
         is ContractSearchType.Type -> "[type], type = [${this.searchType.valueType}]"
         is ContractSearchType.Id -> "[id], id = [${this.searchType.id}]"

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/query/SearchContract.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/query/SearchContract.kt
@@ -5,7 +5,10 @@ import com.fasterxml.jackson.annotation.JsonTypeName
 import com.fasterxml.jackson.annotation.JsonValue
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy
 import com.fasterxml.jackson.databind.annotation.JsonNaming
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import io.provenance.bilateral.interfaces.ContractQueryMsg
+import io.provenance.bilateral.serialization.CosmWasmBigIntegerToUintSerializer
+import java.math.BigInteger
 
 /**
  * See ContractSearchType for JSON payloads for each different type of ask search.
@@ -26,25 +29,13 @@ data class SearchBids(val search: ContractSearchRequest) : ContractQueryMsg
 @JsonNaming(SnakeCaseStrategy::class)
 data class ContractSearchRequest(
     val searchType: ContractSearchType,
-    val pageSize: String? = null,
-    val pageNumber: String? = null,
+    @JsonSerialize(using = CosmWasmBigIntegerToUintSerializer::class)
+    val pageSize: BigInteger? = null,
+    @JsonSerialize(using = CosmWasmBigIntegerToUintSerializer::class)
+    val pageNumber: BigInteger? = null,
 ) {
-    companion object {
-        fun newSearchAsks(
-            searchType: ContractSearchType,
-            pageSize: Int? = null,
-            pageNumber: Int? = null,
-        ): SearchAsks = ContractSearchRequest(searchType, pageSize?.toString(), pageNumber?.toString()).searchAsks()
-
-        fun newSearchBids(
-            searchType: ContractSearchType,
-            pageSize: Int? = null,
-            pageNumber: Int? = null,
-        ): SearchBids = ContractSearchRequest(searchType, pageSize?.toString(), pageNumber?.toString()).searchBids()
-    }
-
-    fun searchAsks(): SearchAsks = SearchAsks(this)
-    fun searchBids(): SearchBids = SearchBids(this)
+    internal fun searchAsks(): SearchAsks = SearchAsks(this)
+    internal fun searchBids(): SearchBids = SearchBids(this)
 }
 
 sealed interface ContractSearchType {

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/serialization/CosmWasmBigIntegerToUintSerializer.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/serialization/CosmWasmBigIntegerToUintSerializer.kt
@@ -1,0 +1,18 @@
+package io.provenance.bilateral.serialization
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.JsonSerializer
+import com.fasterxml.jackson.databind.SerializerProvider
+import java.math.BigInteger
+
+class CosmWasmBigIntegerToUintSerializer : JsonSerializer<BigInteger>() {
+    override fun serialize(value: BigInteger?, gen: JsonGenerator?, serializers: SerializerProvider?) {
+        value?.also { bigInt ->
+            if (bigInt < BigInteger.ZERO) {
+                throw IllegalArgumentException("CosmWasm Uint types require unsigned integers (greater than or equal to zero)")
+            }
+            // Write with BigInteger.toString() which uses the default radix of 10 to create a decimal output, as expected
+            gen?.writeString(bigInt.toString())
+        }
+    }
+}

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/serialization/CosmWasmUTCOffsetDateTimeToTimestampSerializer.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/serialization/CosmWasmUTCOffsetDateTimeToTimestampSerializer.kt
@@ -10,20 +10,20 @@ import java.time.OffsetDateTime
  * Converts an OffsetDateTime into its epoch nanosecond value.  The cosmwasm Timestamp struct requires epoch nanos to
  * track time values, and this will ensure time fields are properly structured.
  */
-class ContractUTCTimestampSerializer : JsonSerializer<OffsetDateTime>() {
+class CosmWasmUTCOffsetDateTimeToTimestampSerializer : JsonSerializer<OffsetDateTime>() {
     private companion object {
         private val SECONDS_TO_NANOS_MULTIPLIER = BigDecimal.valueOf(1_000_000_000L)
     }
 
-    override fun serialize(value: OffsetDateTime, gen: JsonGenerator, serializers: SerializerProvider?) {
-        value.also { odt ->
+    override fun serialize(value: OffsetDateTime?, gen: JsonGenerator?, serializers: SerializerProvider?) {
+        value?.also { odt ->
             // A Long cannot represent all possible epoch nanos, so we default to BigDecimal to ensure large numbers
             // can be handled
             val epochNanos = odt.toEpochSecond()
                 .toBigDecimal()
                 .multiply(SECONDS_TO_NANOS_MULTIPLIER)
                 .plus(odt.nano.toBigDecimal())
-            gen.writeString(epochNanos.toPlainString())
+            gen?.writeString(epochNanos.toPlainString())
         }
     }
 }

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/serialization/CosmWasmUTCTimestampToOffsetDateTimeDeserializer.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/serialization/CosmWasmUTCTimestampToOffsetDateTimeDeserializer.kt
@@ -12,7 +12,7 @@ import java.time.ZoneOffset
 /**
  * See ContractUTCTimestampSerializer for information on why this is necessary for cosmwasm Timestamp struct values.
  */
-class ContractUTCTimestampDeserializer : JsonDeserializer<OffsetDateTime>() {
+class CosmWasmUTCTimestampToOffsetDateTimeDeserializer : JsonDeserializer<OffsetDateTime>() {
     private companion object {
         private val NANO_TO_SECONDS_DIVISOR = BigDecimal.valueOf(1_000_000_000L)
     }

--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/serialization/CosmWasmUintToBigIntegerDeserializer.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/serialization/CosmWasmUintToBigIntegerDeserializer.kt
@@ -1,0 +1,17 @@
+package io.provenance.bilateral.serialization
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import java.math.BigInteger
+
+class CosmWasmUintToBigIntegerDeserializer : JsonDeserializer<BigInteger>() {
+    /**
+     * This is a deserializer for Cosmwasm's Uint types (they include wrappers for most unsigned rust integer types).
+     * The value is returned as a double-quoted numeric value, so simply invoking toBigIntegerOrNull is sufficient
+     * for deserialization.
+     */
+    override fun deserialize(p: JsonParser?, ctxt: DeserializationContext?): BigInteger? = p
+        ?.text
+        ?.toBigIntegerOrNull()
+}

--- a/kotlin-client/src/test/kotlin/io/provenance/bilateral/client/BilateralContractClientLoggerTest.kt
+++ b/kotlin-client/src/test/kotlin/io/provenance/bilateral/client/BilateralContractClientLoggerTest.kt
@@ -1,0 +1,39 @@
+package io.provenance.bilateral.client
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class BilateralContractClientLoggerTest {
+    @Test
+    fun testCustomLogger() {
+        val infoMessages = mutableListOf<String>()
+        val errorMessages = mutableListOf<Pair<String, Exception?>>()
+        val logger = BilateralContractClientLogger.Custom(
+            infoLogger = { message -> infoMessages.add(message) },
+            errorLogger = { message, e -> errorMessages.add(message to e) },
+        )
+        logger.info("info message")
+        assertEquals(
+            expected = "info message",
+            actual = infoMessages.singleOrNull(),
+            message = "A single info message should be sent with the correct text",
+        )
+        assertTrue(
+            actual = errorMessages.isEmpty(),
+            message = "No error messages should have been sent yet",
+        )
+        val exception = Exception("Some exception")
+        logger.error("error message", exception)
+        assertEquals(
+            expected = 1,
+            actual = infoMessages.size,
+            message = "No extra info messages should be sent",
+        )
+        assertEquals(
+            expected = "error message" to exception,
+            actual = errorMessages.singleOrNull(),
+            message = "A single error message should be sent with the proper exception",
+        )
+    }
+}

--- a/smart-contract/Cargo.lock
+++ b/smart-contract/Cargo.lock
@@ -338,7 +338,7 @@ checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "metadata-bilateral-exchange"
-version = "1.0.3"
+version = "1.0.5"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/smart-contract/Cargo.toml
+++ b/smart-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metadata-bilateral-exchange"
-version = "1.0.3"
+version = "1.0.5"
 authors = ["Jake Schwartz <jschwartz@figure.com>", "Ken Talley <ktalley@figure.com>"]
 edition = "2018"
 

--- a/smart-contract/src/contract.rs
+++ b/smart-contract/src/contract.rs
@@ -78,6 +78,6 @@ pub fn migrate(
     msg: MigrateMsg,
 ) -> Result<Response<ProvenanceMsg>, ContractError> {
     match msg {
-        MigrateMsg::ContractUpgrade {} => migrate_contract(&deps),
+        MigrateMsg::ContractUpgrade {} => migrate_contract(deps),
     }
 }

--- a/smart-contract/src/migrate/migrate_contract.rs
+++ b/smart-contract/src/migrate/migrate_contract.rs
@@ -1,4 +1,6 @@
-use crate::storage::contract_info::{get_contract_info, ContractInfo, CONTRACT_VERSION};
+use crate::storage::contract_info::{
+    get_contract_info, set_contract_info, ContractInfo, CONTRACT_VERSION,
+};
 use crate::types::core::error::ContractError;
 use crate::util::extensions::ResultExtensions;
 use cosmwasm_std::{to_binary, DepsMut, Response};
@@ -6,11 +8,12 @@ use provwasm_std::{ProvenanceMsg, ProvenanceQuery};
 use semver::Version;
 
 pub fn migrate_contract(
-    deps: &DepsMut<ProvenanceQuery>,
+    deps: DepsMut<ProvenanceQuery>,
 ) -> Result<Response<ProvenanceMsg>, ContractError> {
     let mut contract_info = get_contract_info(deps.storage)?;
     check_valid_migration_versioning(&contract_info)?;
     contract_info.contract_version = CONTRACT_VERSION.to_string();
+    set_contract_info(deps.storage, &contract_info)?;
     Response::new()
         .add_attribute("action", "migrate_contract")
         .add_attribute("new_version", CONTRACT_VERSION)
@@ -44,8 +47,20 @@ mod tests {
     fn test_successful_migrate_without_options() {
         let mut deps = mock_dependencies(&[]);
         default_instantiate(deps.as_mut().storage);
+        let mut contract_info =
+            get_contract_info(deps.as_ref().storage).expect("contract info should load");
+        contract_info.contract_version = "0.0.1".to_string();
+        set_contract_info(deps.as_mut().storage, &contract_info)
+            .expect("contract info should be stored");
+        assert_eq!(
+            "0.0.1",
+            get_contract_info(deps.as_ref().storage)
+                .expect("contract info should load")
+                .contract_version,
+            "sanity check: expected contract version change to be persisted",
+        );
         let response =
-            migrate_contract(&deps.as_mut()).expect("expected a simple migrate to succeed");
+            migrate_contract(deps.as_mut()).expect("expected a simple migrate to succeed");
         assert!(
             response.messages.is_empty(),
             "migrations should never produce messages",
@@ -65,6 +80,12 @@ mod tests {
             single_attribute_for_key(&response, "new_version"),
             "expected the correct new_version attribute value to be produced",
         );
+        let contract_info =
+            get_contract_info(deps.as_ref().storage).expect("contract info should load");
+        assert_eq!(
+            CONTRACT_VERSION, contract_info.contract_version,
+            "the migration should change the contract version",
+        );
     }
 
     #[test]
@@ -76,7 +97,7 @@ mod tests {
         contract_info.contract_version = "999.999.999".to_string();
         set_contract_info(deps.as_mut().storage, &contract_info)
             .expect("expected contract info to be stored successfully");
-        let err = migrate_contract(&deps.as_mut())
+        let err = migrate_contract(deps.as_mut())
             .expect_err("an error should be produced if the contract is downgraded");
         match err {
             ContractError::InvalidMigration { message } => {

--- a/smart-contract/src/query/get_ask_by_collateral_id.rs
+++ b/smart-contract/src/query/get_ask_by_collateral_id.rs
@@ -1,4 +1,4 @@
-use crate::storage::ask_order_storage::get_ask_order_by_collateral_id;
+use crate::storage::ask_order_storage::may_get_ask_order_by_collateral_id;
 use crate::types::core::error::ContractError;
 use crate::util::extensions::ResultExtensions;
 use cosmwasm_std::{to_binary, Binary, Deps};
@@ -8,20 +8,19 @@ pub fn query_ask_by_collateral_id(
     deps: Deps<ProvenanceQuery>,
     collateral_id: String,
 ) -> Result<Binary, ContractError> {
-    to_binary(&get_ask_order_by_collateral_id(
+    to_binary(&may_get_ask_order_by_collateral_id(
         deps.storage,
         collateral_id,
-    )?)?
+    ))?
     .to_ok()
 }
 
 #[cfg(test)]
 mod tests {
     use crate::query::get_ask_by_collateral_id::query_ask_by_collateral_id;
-    use crate::storage::ask_order_storage::{get_ask_order_by_collateral_id, insert_ask_order};
+    use crate::storage::ask_order_storage::{insert_ask_order, may_get_ask_order_by_collateral_id};
     use crate::test::mock_marker::DEFAULT_MARKER_DENOM;
     use crate::test::request_helpers::{mock_ask_marker_trade, mock_ask_order};
-    use crate::types::core::error::ContractError;
     use crate::types::request::ask_types::ask_order::AskOrder;
     use cosmwasm_std::from_binary;
     use provwasm_mocks::mock_dependencies;
@@ -29,12 +28,10 @@ mod tests {
     #[test]
     fn test_get_ask_by_collateral_id() {
         let mut deps = mock_dependencies(&[]);
-        let err = get_ask_order_by_collateral_id(deps.as_ref().storage, "some_fake_id")
-            .expect_err("an error should occur when no collateral id exists");
-        assert!(
-            matches!(err, ContractError::StorageError { .. }),
-            "a storage error should occur when the ask order cannot be found, but got: {:?}",
-            err,
+        assert_eq!(
+            None,
+            may_get_ask_order_by_collateral_id(deps.as_ref().storage, "some_fake_id"),
+            "no ask order should be found by a collateral id that has not been used",
         );
         // The storage function already has testing for all ask order types, so we just need to
         // ensure the binary portion works here to have a fully-tested set of functionality
@@ -48,8 +45,10 @@ mod tests {
             .expect("the ask order should insert successfully");
         let binary = query_ask_by_collateral_id(deps.as_ref(), "collateral_id".to_string())
             .expect("expected binary to be properly produced from the query");
-        let deserialized_ask_order = from_binary::<AskOrder>(&binary)
-            .expect("expected the binary to deserialize to an ask order");
+        let deserialized_option_ask_order = from_binary::<Option<AskOrder>>(&binary)
+            .expect("expected the binary to deserialize to an optional ask order");
+        let deserialized_ask_order = deserialized_option_ask_order
+            .unwrap_or_else(|| panic!("the ask order should be present in the optional output"));
         assert_eq!(
             ask_order, deserialized_ask_order,
             "expected the inserted value to be identical to the deserialized value",

--- a/smart-contract/src/query/get_contract_info.rs
+++ b/smart-contract/src/query/get_contract_info.rs
@@ -1,19 +1,20 @@
-use crate::storage::contract_info::get_contract_info;
+use crate::storage::contract_info::may_get_contract_info;
 use crate::types::core::error::ContractError;
 use crate::util::extensions::ResultExtensions;
 use cosmwasm_std::{to_binary, Binary, Deps};
 use provwasm_std::ProvenanceQuery;
 
 pub fn query_contract_info(deps: Deps<ProvenanceQuery>) -> Result<Binary, ContractError> {
-    to_binary(&get_contract_info(deps.storage)?)?.to_ok()
+    to_binary(&may_get_contract_info(deps.storage))?.to_ok()
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::contract::query;
+    use crate::storage::contract_info::ContractInfo;
     use crate::test::mock_instantiate::default_instantiate;
     use crate::types::core::msg::QueryMsg;
+    use cosmwasm_std::from_binary;
     use cosmwasm_std::testing::mock_env;
     use provwasm_mocks::mock_dependencies;
 
@@ -23,18 +24,13 @@ mod tests {
         let mut deps = mock_dependencies(&[]);
         default_instantiate(deps.as_mut().storage);
 
-        // query for contract_info
-        let query_contract_info_response =
-            query(deps.as_ref(), mock_env(), QueryMsg::GetContractInfo {});
+        // query for contract_inf
+        let result_binary = query(deps.as_ref(), mock_env(), QueryMsg::GetContractInfo {}).expect(
+            "a binary should be returned after the contract info is available from instantiation",
+        );
 
-        match query_contract_info_response {
-            Ok(contract_info) => {
-                assert_eq!(
-                    contract_info,
-                    to_binary(&get_contract_info(&deps.storage).unwrap()).unwrap()
-                )
-            }
-            Err(error) => panic!("unexpected error: {:?}", error),
-        }
+        from_binary::<Option<ContractInfo>>(&result_binary)
+            .expect("the optional contract info should deserialize from binary")
+            .expect("the option should be populated with contract info");
     }
 }

--- a/smart-contract/src/storage/contract_info.rs
+++ b/smart-contract/src/storage/contract_info.rs
@@ -54,13 +54,19 @@ pub fn get_contract_info(store: &dyn Storage) -> StdResult<ContractInfo> {
     CONTRACT_INFO.load(store)
 }
 
+pub fn may_get_contract_info(store: &dyn Storage) -> Option<ContractInfo> {
+    CONTRACT_INFO.may_load(store).unwrap_or(None)
+}
+
 #[cfg(test)]
 mod tests {
     use provwasm_mocks::mock_dependencies;
 
     use crate::storage::contract_info::{
-        get_contract_info, set_contract_info, ContractInfo, CONTRACT_TYPE, CONTRACT_VERSION,
+        get_contract_info, may_get_contract_info, set_contract_info, ContractInfo, CONTRACT_TYPE,
+        CONTRACT_VERSION,
     };
+    use crate::test::mock_instantiate::default_instantiate;
     use cosmwasm_std::{coins, Addr};
 
     #[test]
@@ -94,5 +100,19 @@ mod tests {
             }
             result => panic!("unexpected error: {:?}", result),
         }
+    }
+
+    #[test]
+    fn test_may_get_contract_info() {
+        let mut deps = mock_dependencies(&[]);
+        assert!(
+            may_get_contract_info(deps.as_ref().storage).is_none(),
+            "contract info should not load when it has not yet been stored",
+        );
+        default_instantiate(deps.as_mut().storage);
+        assert!(
+            may_get_contract_info(deps.as_ref().storage).is_some(),
+            "contract info should be available after instantiation",
+        );
     }
 }

--- a/smart-contract/src/types/request/ask_types/ask_order.rs
+++ b/smart-contract/src/types/request/ask_types/ask_order.rs
@@ -44,10 +44,6 @@ impl AskOrder {
         }
     }
 
-    pub fn get_pk(&self) -> &[u8] {
-        self.id.as_bytes()
-    }
-
     pub fn get_collateral_index(&self) -> String {
         match &self.collateral {
             // Coin trades have no metadata involved - just use self.id as a duplicate index

--- a/smart-contract/src/types/request/bid_types/bid_order.rs
+++ b/smart-contract/src/types/request/bid_types/bid_order.rs
@@ -43,8 +43,4 @@ impl BidOrder {
             descriptor,
         }
     }
-
-    pub fn get_pk(&self) -> &[u8] {
-        self.id.as_bytes()
-    }
 }

--- a/smart-contract/src/types/request/match_report.rs
+++ b/smart-contract/src/types/request/match_report.rs
@@ -1,6 +1,3 @@
-use crate::types::core::error::ContractError;
-use crate::util::extensions::ResultExtensions;
-use cosmwasm_std::{to_binary, Binary};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -14,62 +11,4 @@ pub struct MatchReport {
     pub standard_match_possible: bool,
     pub quote_mismatch_match_possible: bool,
     pub error_messages: Vec<String>,
-}
-impl MatchReport {
-    pub fn new_missing_order<A: Into<String>, B: Into<String>>(
-        ask_id: A,
-        bid_id: B,
-        ask_exists: bool,
-        bid_exists: bool,
-    ) -> Result<Self, ContractError> {
-        let ask_id = ask_id.into();
-        let bid_id = bid_id.into();
-        let error_message = if ask_exists && bid_exists {
-            return ContractError::validation_error(&["created missing order MatchReport with both ask and bid existing. this is a contract bug"]).to_err();
-        } else if ask_exists {
-            format!("BidOrder [{}] was missing from contract storage", &bid_id)
-        } else if bid_exists {
-            format!("AskOrder [{}] was missing from contract storage", &ask_id)
-        } else {
-            format!(
-                "AskOrder [{}] and BidOrder [{}] were missing from contract storage",
-                &ask_id, &bid_id
-            )
-        };
-        Self {
-            ask_id,
-            bid_id,
-            ask_exists,
-            bid_exists,
-            standard_match_possible: false,
-            quote_mismatch_match_possible: false,
-            error_messages: vec![error_message],
-        }
-        .to_ok()
-    }
-
-    pub fn new_existing_orders<A: Into<String>, B: Into<String>, E: Into<String>>(
-        ask_id: A,
-        bid_id: B,
-        standard_match_possible: bool,
-        quote_mismatch_match_possible: bool,
-        error_messages: &[E],
-    ) -> Self
-    where
-        E: Clone,
-    {
-        Self {
-            ask_id: ask_id.into(),
-            bid_id: bid_id.into(),
-            ask_exists: true,
-            bid_exists: true,
-            standard_match_possible,
-            quote_mismatch_match_possible,
-            error_messages: error_messages.iter().cloned().map(|s| s.into()).collect(),
-        }
-    }
-
-    pub fn to_binary(&self) -> Result<Binary, ContractError> {
-        to_binary(self)?.to_ok()
-    }
 }


### PR DESCRIPTION
# Smart Contract Changes
- Bump contract version from `v1.0.4` to `v1.0.5`.
- Stop using a reference to the `DepsMut` in the `migrate_contract` function.
- Migrations were not updating the `ContractInfo` with the new contract version.  Fixed.
- Update `get_ask`, `get_bid`, `get_ask_by_collateral_id`, and `get_contract_info` queries to return nullable responses instead of throwing errors when the target values were not found.
- Trim down the contract size by reducing the amount of functions and additional constructors used in the `get_match_report` functionality.
- Remove various other unneeded functions to reduce contract size.

# Kotlin Client Changes
- Convert numeric types that are currently supplied as Strings (like `sharesToSell`, etc) to use `BigInteger` values instead with proper Jackson annotations to support this.
- Create a builder patter process for the `BilateralContractClient` that is invoked with `BilateralContractClient.builder(pbClient, addressResolver).build()`.  This includes an optional `ObjectMapper` parameter and logging configurations.  This removes the `BilateralContractClient.new` function in favor of the builder pattern.
- Add logging to the `BilateralContractClient` by passing in a `BilateralContractClientLogger` instance.  By default, logging is disabled, but a default Println functionality and the ability to add a custom logging interceptor also exists.
- Use the new logging functionality in the client to log out details of each request sent and log errors when null requests are made and the exceptions are ignored.
- Change `searchAsks` and `searchBids` to require a `ContractSearchRequest` instead of a `SearchAsk` or `SearchBid`, and automatically convert the request to the required value.
- Rename `BroadcastOptions` to `BilateralBroadcastOptions` for a greater factor of uniqueness across libraries.
- Massively improve the speed of the integration tests by changing the blockchain test container's block cut time from `5s` to `100ms`.  This might cause GHA failures and require a follow-up commit.