### PR TITLE
v1.0.9: ContractInfo Legacy Code Cleanup

### DIFF
--- a/smart-contract/Cargo.lock
+++ b/smart-contract/Cargo.lock
@@ -338,7 +338,7 @@ checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "metadata-bilateral-exchange"
-version = "1.0.8"
+version = "1.0.9"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/smart-contract/Cargo.toml
+++ b/smart-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metadata-bilateral-exchange"
-version = "1.0.8"
+version = "1.0.9"
 authors = ["Jake Schwartz <jschwartz@figure.com>", "Ken Talley <ktalley@figure.com>"]
 edition = "2018"
 

--- a/smart-contract/src/migrate/migrate_contract.rs
+++ b/smart-contract/src/migrate/migrate_contract.rs
@@ -1,51 +1,24 @@
 use crate::storage::contract_info::{
-    set_contract_info, ContractInfoV2, CONTRACT_INFO, CONTRACT_TYPE, CONTRACT_VERSION,
+    get_contract_info, set_contract_info, ContractInfoV2, CONTRACT_TYPE, CONTRACT_VERSION,
 };
 use crate::types::core::error::ContractError;
-use crate::util::constants::NHASH;
 use crate::util::extensions::ResultExtensions;
-use cosmwasm_std::{to_binary, Coin, DepsMut, Response, Uint128};
+use cosmwasm_std::{to_binary, DepsMut, Response};
 use provwasm_std::{ProvenanceMsg, ProvenanceQuery};
 use semver::Version;
 
-// TODO: Replace this code with code that exclusively uses ContractInfoV2 once the migration has completed
 pub fn migrate_contract(
     deps: DepsMut<ProvenanceQuery>,
 ) -> Result<Response<ProvenanceMsg>, ContractError> {
-    let contract_info_v1 = CONTRACT_INFO.load(deps.storage)?;
-    // Port the existing contract info over to the new contract info format
-    let mut contract_info_v2 = ContractInfoV2 {
-        admin: contract_info_v1.admin,
-        bind_name: contract_info_v1.bind_name,
-        contract_name: contract_info_v1.contract_name,
-        contract_type: contract_info_v1.contract_type,
-        contract_version: contract_info_v1.contract_version,
-        create_ask_nhash_fee: port_fee_to_nhash(&contract_info_v1.ask_fee),
-        create_bid_nhash_fee: port_fee_to_nhash(&contract_info_v1.bid_fee),
-    };
-    CONTRACT_INFO.remove(deps.storage);
-    check_valid_migration_target(&contract_info_v2)?;
-    contract_info_v2.contract_version = CONTRACT_VERSION.to_string();
-    set_contract_info(deps.storage, &contract_info_v2)?;
+    let mut contract_info = get_contract_info(deps.storage)?;
+    check_valid_migration_target(&contract_info)?;
+    contract_info.contract_version = CONTRACT_VERSION.to_string();
+    set_contract_info(deps.storage, &contract_info)?;
     Response::new()
         .add_attribute("action", "migrate_contract")
         .add_attribute("new_version", CONTRACT_VERSION)
-        .set_data(to_binary(&contract_info_v2)?)
+        .set_data(to_binary(&contract_info)?)
         .to_ok()
-}
-
-fn port_fee_to_nhash(fee_coins: &Option<Vec<Coin>>) -> Uint128 {
-    fee_coins
-        .to_owned()
-        // Get the coin vector or default out to an empty vector
-        .unwrap_or_default()
-        .into_iter()
-        // Get the first result with an nhash denom - this is the only thing that relates to the new format
-        .find(|coin| coin.denom.as_str() == NHASH)
-        // Just grab the amount from the nhash fee coin.  This will be used for Provenance fees
-        .map(|coin| coin.amount)
-        // If all else fails, default out to zero, which is what is used when no fee is to be charged
-        .unwrap_or_else(Uint128::zero)
 }
 
 fn check_valid_migration_target(contract_info: &ContractInfoV2) -> Result<(), ContractError> {
@@ -78,21 +51,13 @@ fn check_valid_migration_target(contract_info: &ContractInfoV2) -> Result<(), Co
 mod tests {
     use crate::migrate::migrate_contract::migrate_contract;
     use crate::storage::contract_info::{
-        get_contract_info, set_contract_info, ContractInfo, ContractInfoV2, CONTRACT_INFO,
-        CONTRACT_TYPE, CONTRACT_VERSION,
+        get_contract_info, set_contract_info, CONTRACT_TYPE, CONTRACT_VERSION,
     };
     use crate::test::cosmos_type_helpers::single_attribute_for_key;
-    use crate::test::mock_instantiate::{
-        default_instantiate, DEFAULT_ADMIN_ADDRESS, DEFAULT_CONTRACT_BIND_NAME,
-        DEFAULT_CONTRACT_NAME,
-    };
+    use crate::test::mock_instantiate::default_instantiate;
     use crate::types::core::error::ContractError;
-    use crate::util::constants::NHASH;
-    use cosmwasm_std::{coin, from_binary, Addr, StdError};
     use provwasm_mocks::mock_dependencies;
 
-    // TODO: Re-enable this test once the migration has completed
-    #[ignore]
     #[test]
     fn test_successful_migrate_without_options() {
         let mut deps = mock_dependencies(&[]);
@@ -138,8 +103,6 @@ mod tests {
         );
     }
 
-    // TODO: Re-enable this test once the migration has completed
-    #[ignore]
     #[test]
     fn test_invalid_migration_scenarios() {
         let mut deps = mock_dependencies(&[]);
@@ -183,171 +146,5 @@ mod tests {
                 e,
             ),
         };
-    }
-
-    // TODO: Delete this test and all below it after the migration has been completed to contract info v2
-    #[test]
-    fn test_invalid_migration_scenarios_with_contract_info_change() {
-        let mut deps = mock_dependencies(&[]);
-        let err = migrate_contract(deps.as_mut())
-            .expect_err("an error should occur when no contract info v1 is set");
-        assert!(
-            matches!(err, ContractError::Std(StdError::NotFound { .. })),
-            "an std not found error should occur when no contract info is available",
-        );
-        let contract_info_v1 = ContractInfo {
-            admin: Addr::unchecked(DEFAULT_ADMIN_ADDRESS),
-            bind_name: DEFAULT_CONTRACT_BIND_NAME.to_string(),
-            contract_name: DEFAULT_CONTRACT_NAME.to_string(),
-            contract_type: CONTRACT_TYPE.to_string(),
-            contract_version: CONTRACT_VERSION.to_string(),
-            ask_fee: None,
-            bid_fee: None,
-        };
-        CONTRACT_INFO
-            .save(deps.as_mut().storage, &contract_info_v1)
-            .expect("contract info v1 should be saved without issue");
-        let err = migrate_contract(deps.as_mut())
-            .expect_err("an error should occur when the contrat version is too low");
-        assert!(
-            matches!(err, ContractError::InvalidMigration { .. }),
-            "an invalid migration error should occur if the contract info has the wrong version, but got: {:?}",
-            err,
-        );
-    }
-
-    #[test]
-    fn test_none_fee_equates_to_zero() {
-        let contract_info_v2 = test_migration_base(&ContractInfo {
-            admin: Addr::unchecked(DEFAULT_ADMIN_ADDRESS),
-            bind_name: DEFAULT_CONTRACT_BIND_NAME.to_string(),
-            contract_name: DEFAULT_CONTRACT_NAME.to_string(),
-            contract_type: CONTRACT_TYPE.to_string(),
-            contract_version: "1.0.7".to_string(),
-            ask_fee: None,
-            bid_fee: None,
-        });
-        assert_eq!(
-            0,
-            contract_info_v2.create_ask_nhash_fee.u128(),
-            "the new ask fee should be zero because no fee was set in the original contract info",
-        );
-        assert_eq!(
-            0,
-            contract_info_v2.create_bid_nhash_fee.u128(),
-            "the new bid fee should be zero because no fee was set in the original contract info",
-        );
-    }
-
-    #[test]
-    fn test_no_nhash_fees_equates_to_zero() {
-        let contract_info_v2 = test_migration_base(&ContractInfo {
-            admin: Addr::unchecked(DEFAULT_ADMIN_ADDRESS),
-            bind_name: DEFAULT_CONTRACT_BIND_NAME.to_string(),
-            contract_name: DEFAULT_CONTRACT_NAME.to_string(),
-            contract_type: CONTRACT_TYPE.to_string(),
-            contract_version: "1.0.7".to_string(),
-            ask_fee: Some(vec![coin(10, "something"), coin(150, "something_else")]),
-            bid_fee: Some(vec![coin(5, "bidthing")]),
-        });
-        assert_eq!(
-            0,
-            contract_info_v2.create_ask_nhash_fee.u128(),
-            "the new ask fee should be zero because no fees were set in nhash",
-        );
-        assert_eq!(
-            0,
-            contract_info_v2.create_bid_nhash_fee.u128(),
-            "the new bid fee should be zero because no fees were set in nhash",
-        );
-    }
-
-    #[test]
-    fn test_nhash_fee_is_properly_ported() {
-        let contract_info_v2 = test_migration_base(&ContractInfo {
-            admin: Addr::unchecked(DEFAULT_ADMIN_ADDRESS),
-            bind_name: DEFAULT_CONTRACT_BIND_NAME.to_string(),
-            contract_name: DEFAULT_CONTRACT_NAME.to_string(),
-            contract_type: CONTRACT_TYPE.to_string(),
-            contract_version: "1.0.7".to_string(),
-            ask_fee: Some(vec![
-                coin(10, "something"),
-                coin(150, "something_else"),
-                coin(50, NHASH),
-            ]),
-            bid_fee: Some(vec![coin(5, "bidthing"), coin(100, NHASH)]),
-        });
-        assert_eq!(
-            50,
-            contract_info_v2.create_ask_nhash_fee.u128(),
-            "the nhash ask fee should be preserved",
-        );
-        assert_eq!(
-            100,
-            contract_info_v2.create_bid_nhash_fee.u128(),
-            "the nhash bid fee should be preserved",
-        );
-    }
-
-    fn test_migration_base(contract_info_v1: &ContractInfo) -> ContractInfoV2 {
-        let mut deps = mock_dependencies(&[]);
-        CONTRACT_INFO
-            .save(deps.as_mut().storage, contract_info_v1)
-            .expect("expected original contract info to be saved without issue");
-        let response =
-            migrate_contract(deps.as_mut()).expect("expected migration to succeed without issue");
-        assert!(
-            response.messages.is_empty(),
-            "migrations should not emit messages",
-        );
-        assert_eq!(
-            2,
-            response.attributes.len(),
-            "the correct number of attribute should be emitted",
-        );
-        assert_eq!(
-            "migrate_contract",
-            single_attribute_for_key(&response, "action"),
-            "the correct value should be set for the action attribute",
-        );
-        assert_eq!(
-            CONTRACT_VERSION,
-            single_attribute_for_key(&response, "new_version"),
-            "the correct value should be set for the new_version attribute",
-        );
-        let contract_info_v2 = get_contract_info(deps.as_ref().storage)
-            .expect("contract info v2 should be available after the migration completes");
-        let binary_deserialized_contract_info = from_binary::<ContractInfoV2>(
-            &response
-                .data
-                .clone()
-                .expect("the response data should be set"),
-        )
-        .expect("contract info v2 should be included in the data in the response");
-        assert_eq!(
-            contract_info_v2, binary_deserialized_contract_info,
-            "the data set in the response should equate to the new contract info value",
-        );
-        assert_eq!(
-            contract_info_v1.admin, contract_info_v2.admin,
-            "the admin value should be properly ported in the new contract info",
-        );
-        assert_eq!(
-            contract_info_v1.bind_name, contract_info_v2.bind_name,
-            "the bind_name value should be properly ported in the new contract info",
-        );
-        assert_eq!(
-            contract_info_v1.contract_name, contract_info_v2.contract_name,
-            "the contract_name value should be properly ported in the new contract info",
-        );
-        assert_eq!(
-            contract_info_v1.contract_type, contract_info_v2.contract_type,
-            "the contract_type value should be properly ported in the new contract info",
-        );
-        assert_eq!(
-            CONTRACT_VERSION, contract_info_v2.contract_version,
-            "the new contract info should include the specified contract version",
-        );
-        contract_info_v2
     }
 }

--- a/smart-contract/src/storage/contract_info.rs
+++ b/smart-contract/src/storage/contract_info.rs
@@ -1,29 +1,15 @@
-use cosmwasm_std::{Addr, Coin, Storage, Uint128};
+use cosmwasm_std::{Addr, Storage, Uint128};
 use cw_storage_plus::Item;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::types::core::error::ContractError;
 
-// TODO: Delete contract info v1 constants and structs after a successful migration
-const NAMESPACE_CONTRACT_INFO: &str = "contract_info";
 const NAMESPACE_CONTRACT_INFO_V2: &str = "contract_info_v2";
 pub const CONTRACT_TYPE: &str = env!("CARGO_CRATE_NAME");
 pub const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-pub const CONTRACT_INFO: Item<ContractInfo> = Item::new(NAMESPACE_CONTRACT_INFO);
 const CONTRACT_INFO_V2: Item<ContractInfoV2> = Item::new(NAMESPACE_CONTRACT_INFO_V2);
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct ContractInfo {
-    pub admin: Addr,
-    pub bind_name: String,
-    pub contract_name: String,
-    pub contract_type: String,
-    pub contract_version: String,
-    pub ask_fee: Option<Vec<Coin>>,
-    pub bid_fee: Option<Vec<Coin>>,
-}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct ContractInfoV2 {


### PR DESCRIPTION
# Smart Contract 
- Bump version from `1.0.8` to `1.0.9`.
- Remove legacy `ContractInfo` struct.
- Put migration code back to normal: it now just validates that the contract type and version are correct, bumps the stored version, and completes the migration.