### PR TITLE
v1.1.2: Kotlin Client Search Bugfix

### DIFF
--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/query/SearchContract.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/query/SearchContract.kt
@@ -94,6 +94,7 @@ sealed interface ContractSearchType {
     class Type private constructor(val valueType: Body) : ContractSearchType {
         constructor(valueType: BilateralRequestType) : this(Body(valueType))
 
+        @JsonNaming(SnakeCaseStrategy::class)
         class Body(val valueType: BilateralRequestType)
     }
 
@@ -105,6 +106,7 @@ sealed interface ContractSearchType {
     class Id private constructor(val id: Body) : ContractSearchType {
         constructor(id: String) : this(Body(id))
 
+        @JsonNaming(SnakeCaseStrategy::class)
         class Body(val id: String)
     }
 
@@ -115,6 +117,7 @@ sealed interface ContractSearchType {
     class Owner private constructor(val owner: Body) : ContractSearchType {
         constructor(owner: String) : this(Body(owner))
 
+        @JsonNaming(SnakeCaseStrategy::class)
         class Body(val owner: String)
     }
 }

--- a/smart-contract/Cargo.lock
+++ b/smart-contract/Cargo.lock
@@ -338,7 +338,7 @@ checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "metadata-bilateral-exchange"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/smart-contract/Cargo.toml
+++ b/smart-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metadata-bilateral-exchange"
-version = "1.1.1"
+version = "1.1.2"
 authors = ["Jake Schwartz <jschwartz@figure.com>", "Ken Talley <ktalley@figure.com>"]
 edition = "2018"
 


### PR DESCRIPTION
# Description
Found a bug in the kotlin client that prevented searches for `value_type` from being executed without exceptions being thrown.

# Smart Contract Changes
- Bumped version to `1.1.2` from `1.1.1`.

# Kotlin Client Changes
- Added `SnakeCaseStrategy` to request bodies for `ContractSearchType` for uniformity, and to fix the issue where `value_type` searches would not succeed due to a malformed json output.
- Fixed the `SearchIntTest` function `testTypeSearch` to search by type instead of owner.  This is why the bug was missed.
- Add an additional test for the `id` search variant to fully extend test coverage for the search functionality.