### PR TITLE
v1.2.0-rc2: Allow asker to provide admin options

### DIFF
--- a/kotlin-client/src/main/kotlin/io/provenance/bilateral/execute/ExecuteMatch.kt
+++ b/kotlin-client/src/main/kotlin/io/provenance/bilateral/execute/ExecuteMatch.kt
@@ -12,10 +12,9 @@ import io.provenance.bilateral.models.AdminMatchOptions
  *
  * @param askId The unique identifier of the ask to match with.
  * @param bidId The unique identifier of the bid to match with.
- * @param adminMatchOptions Various options that alter the behavior of the matching mechanism.  An error will be returned
- * by the contract is this value is non-null when the signer of this message is not the contract admin.  Additionally,
- * using an incorrect variant for the target match (ex: using marker trade admin options for matching two coin trades)
- * will cause a contract error.
+ * @param adminMatchOptions Various options that alter the behavior of the matching mechanism. Using an incorrect
+ * variant for the target match (ex: using marker trade admin options for matching two coin trades) will cause a
+ * contract error.
  */
 @JsonNaming(SnakeCaseStrategy::class)
 @JsonTypeInfo(include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.NAME)

--- a/smart-contract/schema/execute_msg.json
+++ b/smart-contract/schema/execute_msg.json
@@ -219,7 +219,7 @@
   ],
   "definitions": {
     "AdminMatchOptions": {
-      "description": "These options are to be used in matching by the contract admin.  Requests not made by the admin that include admin match options will be rejected.",
+      "description": "These options are to be used in matching to alter the behavior of the matching process.",
       "anyOf": [
         {
           "type": "object",

--- a/smart-contract/schema/query_msg.json
+++ b/smart-contract/schema/query_msg.json
@@ -151,7 +151,7 @@
   ],
   "definitions": {
     "AdminMatchOptions": {
-      "description": "These options are to be used in matching by the contract admin.  Requests not made by the admin that include admin match options will be rejected.",
+      "description": "These options are to be used in matching to alter the behavior of the matching process.",
       "anyOf": [
         {
           "type": "object",

--- a/smart-contract/src/execute/execute_match.rs
+++ b/smart-contract/src/execute/execute_match.rs
@@ -47,9 +47,6 @@ pub fn execute_match(
         handler.push("bid id must not be empty");
     }
     let contract_info = get_contract_info(deps.storage)?;
-    if admin_match_options.is_some() && info.sender != contract_info.admin {
-        handler.push("admin options cannot be provided when the sender is not the admin");
-    }
     // return error if either ids are badly formed
     handler.handle()?;
     // return error if funds sent
@@ -423,19 +420,6 @@ mod tests {
         )
         .expect_err("an error should occur when the bid id is empty");
         assert_validation_error_message(err, "bid id must not be empty");
-        let err = execute_match(
-            deps.as_mut(),
-            mock_env(),
-            mock_info("asker", &[]),
-            "ask_id".to_string(),
-            "bid_id".to_string(),
-            Some(AdminMatchOptions::coin_trade_options(true)),
-        )
-        .expect_err("an error should occur when admin options are provided by a non-admin account");
-        assert_validation_error_message(
-            err,
-            "admin options cannot be provided when the sender is not the admin",
-        );
         let err = execute_match(
             deps.as_mut(),
             mock_env(),

--- a/smart-contract/src/types/request/admin_match_options.rs
+++ b/smart-contract/src/types/request/admin_match_options.rs
@@ -1,8 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-/// These options are to be used in matching by the contract admin.  Requests not made by the admin
-/// that include admin match options will be rejected.
+/// These options are to be used in matching to alter the behavior of the matching process.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum AdminMatchOptions {


### PR DESCRIPTION
# Description
This PR enables the asker to provide admin options.  The asker can never leverage their request to charge the bidder more than the bidder offered, so this action is safe.